### PR TITLE
add *WithFee functions to periphery payments

### DIFF
--- a/contracts/SwapRouter.sol
+++ b/contracts/SwapRouter.sol
@@ -9,7 +9,7 @@ import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import './interfaces/ISwapRouter.sol';
 import './base/PeripheryImmutableState.sol';
 import './base/PeripheryValidation.sol';
-import './base/PeripheryPayments.sol';
+import './base/PeripheryPaymentsWithFee.sol';
 import './base/Multicall.sol';
 import './base/SelfPermit.sol';
 import './libraries/Path.sol';
@@ -23,7 +23,7 @@ contract SwapRouter is
     ISwapRouter,
     PeripheryImmutableState,
     PeripheryValidation,
-    PeripheryPayments,
+    PeripheryPaymentsWithFee,
     Multicall,
     SelfPermit
 {

--- a/contracts/base/PeripheryPayments.sol
+++ b/contracts/base/PeripheryPayments.sol
@@ -18,7 +18,7 @@ abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableSta
     /// @inheritdoc IPeripheryPayments
     function unwrapWETH9(uint256 amountMinimum, address recipient) external payable override {
         uint256 balanceWETH9 = IWETH9(WETH9).balanceOf(address(this));
-        if (amountMinimum > 0) require(balanceWETH9 >= amountMinimum, 'Insufficient WETH9');
+        require(balanceWETH9 >= amountMinimum, 'Insufficient WETH9');
 
         if (balanceWETH9 > 0) {
             IWETH9(WETH9).withdraw(balanceWETH9);
@@ -33,7 +33,7 @@ abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableSta
         address recipient
     ) external payable override {
         uint256 balanceToken = IERC20(token).balanceOf(address(this));
-        if (amountMinimum > 0) require(balanceToken >= amountMinimum, 'Insufficient token');
+        require(balanceToken >= amountMinimum, 'Insufficient token');
 
         if (balanceToken > 0) {
             TransferHelper.safeTransfer(token, recipient, balanceToken);

--- a/contracts/base/PeripheryPayments.sol
+++ b/contracts/base/PeripheryPayments.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.7.5;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/math/SafeMath.sol';
 
 import '../interfaces/IPeripheryPayments.sol';
 import '../interfaces/external/IWETH9.sol';
@@ -11,18 +12,37 @@ import '../libraries/TransferHelper.sol';
 import './PeripheryImmutableState.sol';
 
 abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableState {
+    using SafeMath for uint256;
+
     receive() external payable {
         require(msg.sender == WETH9, 'Not WETH9');
     }
 
     /// @inheritdoc IPeripheryPayments
-    function unwrapWETH9(uint256 amountMinimum, address recipient) external payable override {
+    function unwrapWETH9(
+        uint256 amountMinimum, 
+        address recipient
+    ) external payable override {
+        unwrapWETH9WithFee(amountMinimum, recipient, 0, address(0));
+    }
+
+    /// @inheritdoc IPeripheryPayments
+    function unwrapWETH9WithFee(
+        uint256 amountMinimum, 
+        address recipient,
+        uint256 feePercentage,
+        address feeRecipient
+    ) public payable override {
+        require(feePercentage <= 10, 'Fee');
+
         uint256 balanceWETH9 = IWETH9(WETH9).balanceOf(address(this));
         if (amountMinimum > 0) require(balanceWETH9 >= amountMinimum, 'Insufficient WETH9');
 
         if (balanceWETH9 > 0) {
             IWETH9(WETH9).withdraw(balanceWETH9);
-            TransferHelper.safeTransferETH(recipient, balanceWETH9);
+            uint256 feeAmount = feePercentage == 0 ? 0 : balanceWETH9.mul(feePercentage).div(100);
+            if (feeAmount > 0) TransferHelper.safeTransferETH(feeRecipient, feeAmount);
+            TransferHelper.safeTransferETH(recipient, balanceWETH9 - feeAmount);
         }
     }
 
@@ -32,10 +52,27 @@ abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableSta
         uint256 amountMinimum,
         address recipient
     ) external payable override {
+        sweepTokenWithFee(token, amountMinimum, recipient, 0, address(0));
+    }
+
+    /// @inheritdoc IPeripheryPayments
+    function sweepTokenWithFee(
+        address token,
+        uint256 amountMinimum,
+        address recipient,
+        uint256 feePercentage,
+        address feeRecipient
+    ) public payable override {
+        require(feePercentage <= 10, 'Fee');
+
         uint256 balanceToken = IERC20(token).balanceOf(address(this));
         if (amountMinimum > 0) require(balanceToken >= amountMinimum, 'Insufficient token');
 
-        if (balanceToken > 0) TransferHelper.safeTransfer(token, recipient, balanceToken);
+        if (balanceToken > 0) {
+            uint256 feeAmount = feePercentage == 0 ? 0 : balanceToken.mul(feePercentage).div(100);
+            if (feeAmount > 0) TransferHelper.safeTransfer(token, feeRecipient, feeAmount);
+            TransferHelper.safeTransfer(token, recipient, balanceToken - feeAmount);
+        }
     }
 
     /// @param token The token to pay

--- a/contracts/base/PeripheryPayments.sol
+++ b/contracts/base/PeripheryPayments.sol
@@ -19,16 +19,13 @@ abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableSta
     }
 
     /// @inheritdoc IPeripheryPayments
-    function unwrapWETH9(
-        uint256 amountMinimum, 
-        address recipient
-    ) external payable override {
+    function unwrapWETH9(uint256 amountMinimum, address recipient) external payable override {
         unwrapWETH9WithFee(amountMinimum, recipient, 0, address(0));
     }
 
     /// @inheritdoc IPeripheryPayments
     function unwrapWETH9WithFee(
-        uint256 amountMinimum, 
+        uint256 amountMinimum,
         address recipient,
         uint256 feePercentage,
         address feeRecipient

--- a/contracts/base/PeripheryPayments.sol
+++ b/contracts/base/PeripheryPayments.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.7.5;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
-import '@openzeppelin/contracts/math/SafeMath.sol';
 
 import '../interfaces/IPeripheryPayments.sol';
 import '../interfaces/external/IWETH9.sol';
@@ -12,34 +11,18 @@ import '../libraries/TransferHelper.sol';
 import './PeripheryImmutableState.sol';
 
 abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableState {
-    using SafeMath for uint256;
-
     receive() external payable {
         require(msg.sender == WETH9, 'Not WETH9');
     }
 
     /// @inheritdoc IPeripheryPayments
     function unwrapWETH9(uint256 amountMinimum, address recipient) external payable override {
-        unwrapWETH9WithFee(amountMinimum, recipient, 0, address(0));
-    }
-
-    /// @inheritdoc IPeripheryPayments
-    function unwrapWETH9WithFee(
-        uint256 amountMinimum,
-        address recipient,
-        uint256 feePercentage,
-        address feeRecipient
-    ) public payable override {
-        require(feePercentage <= 10, 'Fee');
-
         uint256 balanceWETH9 = IWETH9(WETH9).balanceOf(address(this));
         if (amountMinimum > 0) require(balanceWETH9 >= amountMinimum, 'Insufficient WETH9');
 
         if (balanceWETH9 > 0) {
             IWETH9(WETH9).withdraw(balanceWETH9);
-            uint256 feeAmount = feePercentage == 0 ? 0 : balanceWETH9.mul(feePercentage).div(100);
-            if (feeAmount > 0) TransferHelper.safeTransferETH(feeRecipient, feeAmount);
-            TransferHelper.safeTransferETH(recipient, balanceWETH9 - feeAmount);
+            TransferHelper.safeTransferETH(recipient, balanceWETH9);
         }
     }
 
@@ -49,26 +32,11 @@ abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableSta
         uint256 amountMinimum,
         address recipient
     ) external payable override {
-        sweepTokenWithFee(token, amountMinimum, recipient, 0, address(0));
-    }
-
-    /// @inheritdoc IPeripheryPayments
-    function sweepTokenWithFee(
-        address token,
-        uint256 amountMinimum,
-        address recipient,
-        uint256 feePercentage,
-        address feeRecipient
-    ) public payable override {
-        require(feePercentage <= 10, 'Fee');
-
         uint256 balanceToken = IERC20(token).balanceOf(address(this));
         if (amountMinimum > 0) require(balanceToken >= amountMinimum, 'Insufficient token');
 
         if (balanceToken > 0) {
-            uint256 feeAmount = feePercentage == 0 ? 0 : balanceToken.mul(feePercentage).div(100);
-            if (feeAmount > 0) TransferHelper.safeTransfer(token, feeRecipient, feeAmount);
-            TransferHelper.safeTransfer(token, recipient, balanceToken - feeAmount);
+            TransferHelper.safeTransfer(token, recipient, balanceToken);
         }
     }
 

--- a/contracts/base/PeripheryPaymentsWithFee.sol
+++ b/contracts/base/PeripheryPaymentsWithFee.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.7.5;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
-import '@openzeppelin/contracts/math/SafeMath.sol';
+import '@uniswap/v3-core/contracts/libraries/LowGasSafeMath.sol';
 
 import './PeripheryPayments.sol';
 import '../interfaces/IPeripheryPaymentsWithFee.sol';
@@ -11,18 +11,19 @@ import '../interfaces/external/IWETH9.sol';
 import '../libraries/TransferHelper.sol';
 
 abstract contract PeripheryPaymentsWithFee is PeripheryPayments, IPeripheryPaymentsWithFee {
-    using SafeMath for uint256;
+    using LowGasSafeMath for uint256;
 
+    /// @inheritdoc IPeripheryPaymentsWithFee
     function unwrapWETH9WithFee(
         uint256 amountMinimum,
         address recipient,
         uint256 feeBips,
         address feeRecipient
     ) public payable override {
-        require(feeBips > 0 && feeBips <= 100, 'Fee');
+        require(feeBips > 0 && feeBips <= 100);
 
         uint256 balanceWETH9 = IWETH9(WETH9).balanceOf(address(this));
-        if (amountMinimum > 0) require(balanceWETH9 >= amountMinimum, 'Insufficient WETH9');
+        require(balanceWETH9 >= amountMinimum, 'Insufficient WETH9');
 
         if (balanceWETH9 > 0) {
             IWETH9(WETH9).withdraw(balanceWETH9);
@@ -32,6 +33,7 @@ abstract contract PeripheryPaymentsWithFee is PeripheryPayments, IPeripheryPayme
         }
     }
 
+    /// @inheritdoc IPeripheryPaymentsWithFee
     function sweepTokenWithFee(
         address token,
         uint256 amountMinimum,
@@ -39,10 +41,10 @@ abstract contract PeripheryPaymentsWithFee is PeripheryPayments, IPeripheryPayme
         uint256 feeBips,
         address feeRecipient
     ) public payable override {
-        require(feeBips > 0 && feeBips <= 100, 'Fee');
+        require(feeBips > 0 && feeBips <= 100);
 
         uint256 balanceToken = IERC20(token).balanceOf(address(this));
-        if (amountMinimum > 0) require(balanceToken >= amountMinimum, 'Insufficient token');
+        require(balanceToken >= amountMinimum, 'Insufficient token');
 
         if (balanceToken > 0) {
             uint256 feeAmount = balanceToken.mul(feeBips) / 10_000;

--- a/contracts/base/PeripheryPaymentsWithFee.sol
+++ b/contracts/base/PeripheryPaymentsWithFee.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/math/SafeMath.sol';
+
+import './PeripheryPayments.sol';
+import '../interfaces/IPeripheryPaymentsWithFee.sol';
+
+import '../interfaces/external/IWETH9.sol';
+import '../libraries/TransferHelper.sol';
+
+abstract contract PeripheryPaymentsWithFee is PeripheryPayments, IPeripheryPaymentsWithFee {
+    using SafeMath for uint256;
+
+    function unwrapWETH9WithFee(
+        uint256 amountMinimum,
+        address recipient,
+        uint256 feeBips,
+        address feeRecipient
+    ) public payable override {
+        require(feeBips > 0 && feeBips <= 100, 'Fee');
+
+        uint256 balanceWETH9 = IWETH9(WETH9).balanceOf(address(this));
+        if (amountMinimum > 0) require(balanceWETH9 >= amountMinimum, 'Insufficient WETH9');
+
+        if (balanceWETH9 > 0) {
+            IWETH9(WETH9).withdraw(balanceWETH9);
+            uint256 feeAmount = balanceWETH9.mul(feeBips) / 10_000;
+            if (feeAmount > 0) TransferHelper.safeTransferETH(feeRecipient, feeAmount);
+            TransferHelper.safeTransferETH(recipient, balanceWETH9 - feeAmount);
+        }
+    }
+
+    function sweepTokenWithFee(
+        address token,
+        uint256 amountMinimum,
+        address recipient,
+        uint256 feeBips,
+        address feeRecipient
+    ) public payable override {
+        require(feeBips > 0 && feeBips <= 100, 'Fee');
+
+        uint256 balanceToken = IERC20(token).balanceOf(address(this));
+        if (amountMinimum > 0) require(balanceToken >= amountMinimum, 'Insufficient token');
+
+        if (balanceToken > 0) {
+            uint256 feeAmount = balanceToken.mul(feeBips) / 10_000;
+            if (feeAmount > 0) TransferHelper.safeTransfer(token, feeRecipient, feeAmount);
+            TransferHelper.safeTransfer(token, recipient, balanceToken - feeAmount);
+        }
+    }
+}

--- a/contracts/interfaces/IPeripheryPayments.sol
+++ b/contracts/interfaces/IPeripheryPayments.sol
@@ -8,11 +8,32 @@ interface IPeripheryPayments {
     /// @dev The amountMinimum parameter prevents malicious contracts from stealing WETH9 from users.
     function unwrapWETH9(uint256 amountMinimum, address recipient) external payable;
 
-    /// @notice Sends the full amount of a token held by this contract to the given recipient
+    /// @notice Unwraps the contract's WETH9 balance and sends it to recipient as ETH, with an optional percentage
+    /// going to the specified fee address
+    /// @dev The amountMinimum parameter prevents malicious contracts from stealing WETH9 from users.
+    function unwrapWETH9WithFee(
+        uint256 amountMinimum,
+        address recipient,
+        uint256 feePercentage,
+        address feeRecipient
+    ) external payable;
+
+    /// @notice Calculates the full amount of a token held by this contract and sends it to the given recipient
     /// @dev The amountMinimum parameter prevents malicious contracts from stealing the token from users
     function sweepToken(
         address token,
         uint256 amountMinimum,
         address recipient
+    ) external payable;
+
+    /// @notice Calculates the full amount of a token held by this contract and sends it to the given recipient, with an
+    /// optional percentage going to the specified fee address
+    /// @dev The amountMinimum parameter prevents malicious contracts from stealing the token from users
+    function sweepTokenWithFee(
+        address token,
+        uint256 amountMinimum,
+        address recipient,
+        uint256 feePercentage,
+        address feeRecipient
     ) external payable;
 }

--- a/contracts/interfaces/IPeripheryPayments.sol
+++ b/contracts/interfaces/IPeripheryPayments.sol
@@ -10,7 +10,7 @@ interface IPeripheryPayments {
     /// @param recipient The address receiving ETH
     function unwrapWETH9(uint256 amountMinimum, address recipient) external payable;
 
-    /// @notice Calculates the full amount of a token held by this contract and sends it to the given recipient
+    /// @notice Transfers the full amount of a token held by this contract to recipient
     /// @dev The amountMinimum parameter prevents malicious contracts from stealing the token from users
     /// @param token The contract address of the token which will be transferred to `recipient`
     /// @param amountMinimum The minimum amount of token required for a transfer

--- a/contracts/interfaces/IPeripheryPayments.sol
+++ b/contracts/interfaces/IPeripheryPayments.sol
@@ -10,16 +10,6 @@ interface IPeripheryPayments {
     /// @param recipient The address receiving ETH
     function unwrapWETH9(uint256 amountMinimum, address recipient) external payable;
 
-    /// @notice Unwraps the contract's WETH9 balance and sends it to recipient as ETH, with an optional percentage
-    /// going to the specified fee address
-    /// @dev The amountMinimum parameter prevents malicious contracts from stealing WETH9 from users.
-    function unwrapWETH9WithFee(
-        uint256 amountMinimum,
-        address recipient,
-        uint256 feePercentage,
-        address feeRecipient
-    ) external payable;
-
     /// @notice Calculates the full amount of a token held by this contract and sends it to the given recipient
     /// @dev The amountMinimum parameter prevents malicious contracts from stealing the token from users
     /// @param token The contract address of the token which will be transferred to `recipient`
@@ -29,16 +19,5 @@ interface IPeripheryPayments {
         address token,
         uint256 amountMinimum,
         address recipient
-    ) external payable;
-
-    /// @notice Calculates the full amount of a token held by this contract and sends it to the given recipient, with an
-    /// optional percentage going to the specified fee address
-    /// @dev The amountMinimum parameter prevents malicious contracts from stealing the token from users
-    function sweepTokenWithFee(
-        address token,
-        uint256 amountMinimum,
-        address recipient,
-        uint256 feePercentage,
-        address feeRecipient
     ) external payable;
 }

--- a/contracts/interfaces/IPeripheryPaymentsWithFee.sol
+++ b/contracts/interfaces/IPeripheryPaymentsWithFee.sol
@@ -6,8 +6,8 @@ import './IPeripheryPayments.sol';
 /// @title Periphery Payments
 /// @notice Functions to ease deposits and withdrawals of ETH
 interface IPeripheryPaymentsWithFee is IPeripheryPayments {
-    /// @notice Unwraps the contract's WETH9 balance and sends it to recipient as ETH, with an optional percentage
-    /// going to the specified fee address
+    /// @notice Unwraps the contract's WETH9 balance and sends it to recipient as ETH, with a percentage between
+    /// 0 (exclusive), and 1 (inclusive) going to feeRecipient
     /// @dev The amountMinimum parameter prevents malicious contracts from stealing WETH9 from users.
     function unwrapWETH9WithFee(
         uint256 amountMinimum,
@@ -16,8 +16,8 @@ interface IPeripheryPaymentsWithFee is IPeripheryPayments {
         address feeRecipient
     ) external payable;
 
-    /// @notice Calculates the full amount of a token held by this contract and sends it to the given recipient, with an
-    /// optional percentage going to the specified fee address
+    /// @notice Transfers the full amount of a token held by this contract to recipient, with a percentage between
+    /// 0 (exclusive) and 1 (inclusive) going to feeRecipient
     /// @dev The amountMinimum parameter prevents malicious contracts from stealing the token from users
     function sweepTokenWithFee(
         address token,

--- a/contracts/interfaces/IPeripheryPaymentsWithFee.sol
+++ b/contracts/interfaces/IPeripheryPaymentsWithFee.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+
+import './IPeripheryPayments.sol';
+
+/// @title Periphery Payments
+/// @notice Functions to ease deposits and withdrawals of ETH
+interface IPeripheryPaymentsWithFee is IPeripheryPayments {
+    /// @notice Unwraps the contract's WETH9 balance and sends it to recipient as ETH, with an optional percentage
+    /// going to the specified fee address
+    /// @dev The amountMinimum parameter prevents malicious contracts from stealing WETH9 from users.
+    function unwrapWETH9WithFee(
+        uint256 amountMinimum,
+        address recipient,
+        uint256 feeBips,
+        address feeRecipient
+    ) external payable;
+
+    /// @notice Calculates the full amount of a token held by this contract and sends it to the given recipient, with an
+    /// optional percentage going to the specified fee address
+    /// @dev The amountMinimum parameter prevents malicious contracts from stealing the token from users
+    function sweepTokenWithFee(
+        address token,
+        uint256 amountMinimum,
+        address recipient,
+        uint256 feeBips,
+        address feeRecipient
+    ) external payable;
+}

--- a/test/SwapRouter.spec.ts
+++ b/test/SwapRouter.spec.ts
@@ -853,5 +853,64 @@ describe('SwapRouter', () => {
         })
       })
     })
+
+    describe('*WithFee', () => {
+      const feeRecipient = '0xfEE0000000000000000000000000000000000000'
+
+      it('#sweepTokenWithFee', async () => {
+        const amountOutMinimum = 100
+        const params = {
+          path: encodePath([tokens[0].address, tokens[1].address], [FeeAmount.MEDIUM]),
+          recipient: router.address,
+          deadline: 1,
+          amountIn: 102,
+          amountOutMinimum,
+        }
+
+        const data = [
+          router.interface.encodeFunctionData('exactInput', [params]),
+          router.interface.encodeFunctionData('sweepTokenWithFee', [
+            tokens[1].address,
+            amountOutMinimum,
+            trader.address,
+            100,
+            feeRecipient,
+          ]),
+        ]
+
+        await router.connect(trader).multicall(data)
+
+        const balance = await tokens[1].balanceOf(feeRecipient)
+        expect(balance.eq(1)).to.be.eq(true)
+      })
+
+      it('#unwrapWETH9WithFee', async () => {
+        await createPoolWETH9(tokens[0].address)
+
+        const amountOutMinimum = 100
+        const params = {
+          path: encodePath([tokens[0].address, weth9.address], [FeeAmount.MEDIUM]),
+          recipient: router.address,
+          deadline: 1,
+          amountIn: 102,
+          amountOutMinimum,
+        }
+
+        const data = [
+          router.interface.encodeFunctionData('exactInput', [params]),
+          router.interface.encodeFunctionData('unwrapWETH9WithFee', [
+            amountOutMinimum,
+            trader.address,
+            100,
+            feeRecipient,
+          ]),
+        ]
+
+        await router.connect(trader).multicall(data)
+
+        const balance = await waffle.provider.getBalance(feeRecipient)
+        expect(balance.eq(1)).to.be.eq(true)
+      })
+    })
   })
 })

--- a/test/__snapshots__/NonfungiblePositionManager.spec.ts.snap
+++ b/test/__snapshots__/NonfungiblePositionManager.spec.ts.snap
@@ -30,6 +30,6 @@ exports[`NonfungiblePositionManager #transferFrom gas 1`] = `84234`;
 
 exports[`NonfungiblePositionManager #transferFrom gas comes from approved 1`] = `75434`;
 
-exports[`NonfungiblePositionManager bytecode size 1`] = `24480`;
+exports[`NonfungiblePositionManager bytecode size 1`] = `24468`;
 
 exports[`NonfungiblePositionManager multicall exit gas 1`] = `172424`;

--- a/test/__snapshots__/SwapRouter.gas.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.gas.spec.ts.snap
@@ -1,31 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `181649`;
+exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `181650`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `111234`;
+exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `111235`;
 
 exports[`SwapRouter gas tests #exactInput 0 -> 1 minimal 1`] = `104691`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `138182`;
+exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `138250`;
 
 exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `111256`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `110674`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `110695`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `137616`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `137704`;
 
-exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `110878`;
+exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `110898`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `177621`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `177630`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `115832`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `115841`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `139413`;
+exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `139489`;
 
-exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `143687`;
+exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `143762`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `115361`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `115382`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `138942`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `139030`;
 
-exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `122111`;
+exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `122198`;

--- a/test/__snapshots__/SwapRouter.gas.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.gas.spec.ts.snap
@@ -6,26 +6,26 @@ exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `111235`;
 
 exports[`SwapRouter gas tests #exactInput 0 -> 1 minimal 1`] = `104691`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `138250`;
+exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `138231`;
 
 exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `111256`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `110695`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `110675`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `137704`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `137665`;
 
-exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `110898`;
+exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `110878`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `177630`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `177622`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `115841`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `115833`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `139489`;
+exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `139462`;
 
-exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `143762`;
+exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `143760`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `115382`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `115362`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `139030`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `138991`;
 
-exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `122198`;
+exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `122184`;

--- a/test/__snapshots__/SwapRouter.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter bytecode size 1`] = `12359`;
+exports[`SwapRouter bytecode size 1`] = `12024`;

--- a/test/__snapshots__/SwapRouter.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter bytecode size 1`] = `10878`;
+exports[`SwapRouter bytecode size 1`] = `12359`;


### PR DESCRIPTION
note: with this design, WETH/ETH fees are collected in the same form as the user receives them. i.e., if the user is getting ETH, the fee is in ETH, and same for WETH

closes #55 