### PR TITLE
make the calldata for all swaps and exits portable

### DIFF
--- a/contracts/NonfungiblePositionManager.sol
+++ b/contracts/NonfungiblePositionManager.sol
@@ -314,6 +314,9 @@ contract NonfungiblePositionManager is
         returns (uint256 amount0, uint256 amount1)
     {
         require(params.amount0Max > 0 || params.amount1Max > 0);
+        // allow collecting to the nft position manager address with address 0
+        address recipient = params.recipient == address(0) ? address(this) : params.recipient;
+
         Position storage position = _positions[params.tokenId];
 
         PoolAddress.PoolKey memory poolKey = _poolIdToPoolKey[position.poolId];
@@ -356,7 +359,7 @@ contract NonfungiblePositionManager is
 
         // the actual amounts collected are returned
         (amount0, amount1) = pool.collect(
-            params.recipient,
+            recipient,
             position.tickLower,
             position.tickUpper,
             amount0Collect,
@@ -367,7 +370,7 @@ contract NonfungiblePositionManager is
         // instead of the actual amount so we can burn the token
         (position.tokensOwed0, position.tokensOwed1) = (tokensOwed0 - amount0Collect, tokensOwed1 - amount1Collect);
 
-        emit Collect(params.tokenId, params.recipient, amount0Collect, amount1Collect);
+        emit Collect(params.tokenId, recipient, amount0Collect, amount1Collect);
     }
 
     /// @inheritdoc INonfungiblePositionManager

--- a/contracts/SwapRouter.sol
+++ b/contracts/SwapRouter.sol
@@ -89,6 +89,9 @@ contract SwapRouter is
         uint160 sqrtPriceLimitX96,
         SwapCallbackData memory data
     ) private returns (uint256 amountOut) {
+        // we allow swapping to the router address with address 0
+        if (recipient == address(0)) recipient = address(this);
+
         (address tokenIn, address tokenOut, uint24 fee) = data.path.decodeFirstPool();
 
         bool zeroForOne = tokenIn < tokenOut;
@@ -168,6 +171,8 @@ contract SwapRouter is
         uint160 sqrtPriceLimitX96,
         SwapCallbackData memory data
     ) private returns (uint256 amountIn) {
+        if (recipient == address(0)) recipient = address(this);
+
         (address tokenOut, address tokenIn, uint24 fee) = data.path.decodeFirstPool();
 
         bool zeroForOne = tokenIn < tokenOut;

--- a/contracts/SwapRouter.sol
+++ b/contracts/SwapRouter.sol
@@ -89,7 +89,7 @@ contract SwapRouter is
         uint160 sqrtPriceLimitX96,
         SwapCallbackData memory data
     ) private returns (uint256 amountOut) {
-        // we allow swapping to the router address with address 0
+        // allow swapping to the router address with address 0
         if (recipient == address(0)) recipient = address(this);
 
         (address tokenIn, address tokenOut, uint24 fee) = data.path.decodeFirstPool();
@@ -171,7 +171,7 @@ contract SwapRouter is
         uint160 sqrtPriceLimitX96,
         SwapCallbackData memory data
     ) private returns (uint256 amountIn) {
-        // we allow swapping to the router address with address 0
+        // allow swapping to the router address with address 0
         if (recipient == address(0)) recipient = address(this);
 
         (address tokenOut, address tokenIn, uint24 fee) = data.path.decodeFirstPool();

--- a/contracts/SwapRouter.sol
+++ b/contracts/SwapRouter.sol
@@ -171,6 +171,7 @@ contract SwapRouter is
         uint160 sqrtPriceLimitX96,
         SwapCallbackData memory data
     ) private returns (uint256 amountIn) {
+        // we allow swapping to the router address with address 0
         if (recipient == address(0)) recipient = address(this);
 
         (address tokenOut, address tokenIn, uint24 fee) = data.path.decodeFirstPool();

--- a/test/SwapRouter.gas.spec.ts
+++ b/test/SwapRouter.gas.spec.ts
@@ -122,7 +122,7 @@ describe('SwapRouter gas tests', () => {
 
     const params = {
       path: encodePath(tokens, new Array(tokens.length - 1).fill(FeeAmount.MEDIUM)),
-      recipient: outputIsWETH9 ? router.address : trader.address,
+      recipient: outputIsWETH9 ? constants.AddressZero : trader.address,
       deadline: 1,
       amountIn,
       amountOutMinimum,
@@ -157,7 +157,7 @@ describe('SwapRouter gas tests', () => {
         sqrtPriceLimitX96 ?? tokenIn.toLowerCase() < tokenOut.toLowerCase()
           ? BigNumber.from('4295128740')
           : BigNumber.from('1461446703485210103287273052203988822378723970341'),
-      recipient: outputIsWETH9 ? router.address : trader.address,
+      recipient: outputIsWETH9 ? constants.AddressZero : trader.address,
       deadline: 1,
       amountIn,
       amountOutMinimum,
@@ -183,7 +183,7 @@ describe('SwapRouter gas tests', () => {
 
     const params = {
       path: encodePath(tokens.slice().reverse(), new Array(tokens.length - 1).fill(FeeAmount.MEDIUM)),
-      recipient: outputIsWETH9 ? router.address : trader.address,
+      recipient: outputIsWETH9 ? constants.AddressZero : trader.address,
       deadline: 1,
       amountOut,
       amountInMaximum,
@@ -212,7 +212,7 @@ describe('SwapRouter gas tests', () => {
       tokenIn,
       tokenOut,
       fee: FeeAmount.MEDIUM,
-      recipient: outputIsWETH9 ? router.address : trader.address,
+      recipient: outputIsWETH9 ? constants.AddressZero : trader.address,
       deadline: 1,
       amountOut,
       amountInMaximum,

--- a/test/SwapRouter.spec.ts
+++ b/test/SwapRouter.spec.ts
@@ -149,7 +149,7 @@ describe('SwapRouter', () => {
 
         const params = {
           path: encodePath(tokens, new Array(tokens.length - 1).fill(FeeAmount.MEDIUM)),
-          recipient: outputIsWETH9 ? router.address : trader.address,
+          recipient: outputIsWETH9 ? constants.AddressZero : trader.address,
           deadline: 1,
           amountIn,
           amountOutMinimum,
@@ -382,7 +382,7 @@ describe('SwapRouter', () => {
             sqrtPriceLimitX96 ?? tokenIn.toLowerCase() < tokenOut.toLowerCase()
               ? BigNumber.from('4295128740')
               : BigNumber.from('1461446703485210103287273052203988822378723970341'),
-          recipient: outputIsWETH9 ? router.address : trader.address,
+          recipient: outputIsWETH9 ? constants.AddressZero : trader.address,
           deadline: 1,
           amountIn,
           amountOutMinimum,
@@ -514,7 +514,7 @@ describe('SwapRouter', () => {
 
         const params = {
           path: encodePath(tokens.slice().reverse(), new Array(tokens.length - 1).fill(FeeAmount.MEDIUM)),
-          recipient: outputIsWETH9 ? router.address : trader.address,
+          recipient: outputIsWETH9 ? constants.AddressZero : trader.address,
           deadline: 1,
           amountOut,
           amountInMaximum,
@@ -734,7 +734,7 @@ describe('SwapRouter', () => {
           tokenIn,
           tokenOut,
           fee: FeeAmount.MEDIUM,
-          recipient: outputIsWETH9 ? router.address : trader.address,
+          recipient: outputIsWETH9 ? constants.AddressZero : trader.address,
           deadline: 1,
           amountOut,
           amountInMaximum,

--- a/test/__snapshots__/NonfungiblePositionManager.spec.ts.snap
+++ b/test/__snapshots__/NonfungiblePositionManager.spec.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`NonfungiblePositionManager #burn gas 1`] = `41297`;
 
-exports[`NonfungiblePositionManager #collect gas transfers both 1`] = `98493`;
+exports[`NonfungiblePositionManager #collect gas transfers both 1`] = `98570`;
 
-exports[`NonfungiblePositionManager #collect gas transfers token0 only 1`] = `111820`;
+exports[`NonfungiblePositionManager #collect gas transfers token0 only 1`] = `111897`;
 
-exports[`NonfungiblePositionManager #collect gas transfers token1 only 1`] = `112027`;
+exports[`NonfungiblePositionManager #collect gas transfers token1 only 1`] = `112104`;
 
 exports[`NonfungiblePositionManager #createAndInitializePoolIfNecessary gas 1`] = `4611843`;
 
@@ -34,6 +34,6 @@ exports[`NonfungiblePositionManager #transferFrom gas 1`] = `79091`;
 
 exports[`NonfungiblePositionManager #transferFrom gas comes from approved 1`] = `67491`;
 
-exports[`NonfungiblePositionManager bytecode size 1`] = `24440`;
+exports[`NonfungiblePositionManager bytecode size 1`] = `24450`;
 
-exports[`NonfungiblePositionManager multicall exit gas 1`] = `142910`;
+exports[`NonfungiblePositionManager multicall exit gas 1`] = `142949`;

--- a/test/__snapshots__/SwapRouter.gas.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.gas.spec.ts.snap
@@ -1,31 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `171814`;
+exports[`SwapRouter gas tests #exactInput 0 -> 1 -> 2 1`] = `171860`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `107417`;
+exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `107440`;
 
 exports[`SwapRouter gas tests #exactInput 0 -> 1 minimal 1`] = `97777`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `127469`;
+exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `127271`;
 
-exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `105730`;
+exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `105753`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `106879`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `106902`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `126925`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `126727`;
 
-exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `105374`;
+exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `105397`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `168591`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `168637`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `111415`;
+exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `111438`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `128700`;
+exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `128502`;
 
-exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `113803`;
+exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `113826`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `111644`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `111667`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `128929`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `128731`;
 
-exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `114214`;
+exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `114237`;

--- a/test/__snapshots__/SwapRouter.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapRouter bytecode size 1`] = `12072`;
+exports[`SwapRouter bytecode size 1`] = `12136`;


### PR DESCRIPTION
allows the user to swap to the swap router or nft contract (for unwrapping or taking fees) by specifying address 0