### PR TITLE
Change thresholds for range location on lower righthand corner curve visual

### DIFF
--- a/contracts/libraries/NFTSVG.sol
+++ b/contracts/libraries/NFTSVG.sol
@@ -360,23 +360,23 @@ library NFTSVG {
 
     function rangeLocation(int24 tickLower, int24 tickUpper) internal pure returns (string memory, string memory) {
         int24 midPoint = (tickLower + tickUpper) / 2;
-        if (midPoint < -100_000) {
+        if (midPoint < -125_000) {
             return ('8', '7');
-        } else if (midPoint < -50_000) {
+        } else if (midPoint < -75_000) {
             return ('8', '10.5');
-        } else if (midPoint < -10_000) {
+        } else if (midPoint < -25_000) {
             return ('8', '14.25');
-        } else if (midPoint < -100) {
+        } else if (midPoint < -5_000) {
             return ('10', '18');
         } else if (midPoint < 0) {
             return ('11', '21');
-        } else if (midPoint < 100) {
+        } else if (midPoint < 5_000) {
             return ('13', '23');
-        } else if (midPoint < 10_000) {
+        } else if (midPoint < 25_000) {
             return ('15', '25');
-        } else if (midPoint < 50_000) {
+        } else if (midPoint < 75_000) {
             return ('18', '26');
-        } else if (midPoint < 100_000) {
+        } else if (midPoint < 125_000) {
             return ('21', '27');
         } else {
             return ('24', '27');

--- a/test/NFTDescriptor.spec.ts
+++ b/test/NFTDescriptor.spec.ts
@@ -728,62 +728,62 @@ describe('NFTDescriptor', () => {
     })
   })
 
-  describe('#rangeLocation', () => {
-    it('returns the correct coordinates when range midpoint under -100_000', async () => {
+  describe.only('#rangeLocation', () => {
+    it('returns the correct coordinates when range midpoint under -125_000', async () => {
       const coords = await nftDescriptor.rangeLocation(-887_272, -887_100)
       expect(coords[0]).to.eq('8')
       expect(coords[1]).to.eq('7')
     })
 
-    it('returns the correct coordinates when range midpoint is between -100_000 and -50_000', async () => {
+    it('returns the correct coordinates when range midpoint is between -125_000 and -75_000', async () => {
       const coords = await nftDescriptor.rangeLocation(-100_000, -90_000)
       expect(coords[0]).to.eq('8')
       expect(coords[1]).to.eq('10.5')
     })
 
-    it('returns the correct coordinates when range midpoint is between -50_000 and -10_000', async () => {
+    it('returns the correct coordinates when range midpoint is between -75_000 and -25_000', async () => {
       const coords = await nftDescriptor.rangeLocation(-50_000, -20_000)
       expect(coords[0]).to.eq('8')
       expect(coords[1]).to.eq('14.25')
     })
 
-    it('returns the correct coordinates when range midpoint is between -10_000 and -100', async () => {
+    it('returns the correct coordinates when range midpoint is between -25_000 and -5_000', async () => {
       const coords = await nftDescriptor.rangeLocation(-10_000, -5_000)
       expect(coords[0]).to.eq('10')
       expect(coords[1]).to.eq('18')
     })
 
-    it('returns the correct coordinates when range midpoint is between -100 and 0', async () => {
-      const coords = await nftDescriptor.rangeLocation(-5, -1)
+    it('returns the correct coordinates when range midpoint is between -5_000 and 0', async () => {
+      const coords = await nftDescriptor.rangeLocation(-5_000, -4_000)
       expect(coords[0]).to.eq('11')
       expect(coords[1]).to.eq('21')
     })
 
-    it('returns the correct coordinates when range midpoint is between 0 and 100', async () => {
-      const coords = await nftDescriptor.rangeLocation(1, 100)
+    it('returns the correct coordinates when range midpoint is between 0 and 5_000', async () => {
+      const coords = await nftDescriptor.rangeLocation(4_000, 5_000)
       expect(coords[0]).to.eq('13')
       expect(coords[1]).to.eq('23')
     })
 
-    it('returns the correct coordinates when range midpoint is between 100 and 10_000', async () => {
-      const coords = await nftDescriptor.rangeLocation(500, 100)
+    it('returns the correct coordinates when range midpoint is between 5_000 and 25_000', async () => {
+      const coords = await nftDescriptor.rangeLocation(10_000, 15_000)
       expect(coords[0]).to.eq('15')
       expect(coords[1]).to.eq('25')
     })
 
-    it('returns the correct coordinates when range midpoint is between 10_000 and 50_000', async () => {
-      const coords = await nftDescriptor.rangeLocation(10_000, 30_000)
+    it('returns the correct coordinates when range midpoint is between 25_000 and 75_000', async () => {
+      const coords = await nftDescriptor.rangeLocation(25_000, 50_000)
       expect(coords[0]).to.eq('18')
       expect(coords[1]).to.eq('26')
     })
 
-    it('returns the correct coordinates when range midpoint is between 50_000 and 100_000', async () => {
-      const coords = await nftDescriptor.rangeLocation(100_000, 99_500)
+    it('returns the correct coordinates when range midpoint is between 75_000 and 125_000', async () => {
+      const coords = await nftDescriptor.rangeLocation(100_000, 125_000)
       expect(coords[0]).to.eq('21')
       expect(coords[1]).to.eq('27')
     })
 
-    it('returns the correct coordinates when range midpoint is above 100_000', async () => {
+    it('returns the correct coordinates when range midpoint is above 125_000', async () => {
       const coords = await nftDescriptor.rangeLocation(200_000, 100_000)
       expect(coords[0]).to.eq('24')
       expect(coords[1]).to.eq('27')


### PR DESCRIPTION
Trivial, but it's been sort of bugging me that the coord on the lower right hand curve swings really hard at small price increases. The threshold changes in terms of price (instead of ticks) look like this:
```
price
1.01 ----> 1.64
2.70-----> 12.00
148------> 1_807
22_018---> 268_200
```



<img width="77" alt="Screen Shot 2021-05-27 at 12 40 15 PM" src="https://user-images.githubusercontent.com/5539720/119864580-c1520480-bee8-11eb-901e-a913bd5b7aa3.png">
