### PR TITLE
Create sdkPoolExamples.ts

### DIFF
--- a/contracts/examples/sdkPoolExamples.ts
+++ b/contracts/examples/sdkPoolExamples.ts
@@ -1,0 +1,83 @@
+
+import { ethers } from "ethers";
+import { Pool } from "@uniswap/v3-sdk";
+import { Token } from "@uniswap/sdk-core";
+import { abi as IUniswapV3PoolABI } from "@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json";
+
+const provider = new ethers.providers.JsonRpcProvider(
+  "https://mainnet.infura.io/v3/<YOUR-ENDPOINT-HERE>"
+);
+
+const poolAddress = "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8";
+
+const poolContract = new ethers.Contract(
+  poolAddress,
+  IUniswapV3PoolABI,
+  provider
+);
+
+interface Immutables {
+  factory: string;
+  token0: string;
+  token1: string;
+  fee: number;
+  tickSpacing: number;
+  maxLiquidityPerTick: ethers.BigNumber;
+}
+
+interface State {
+  liquidity: ethers.BigNumber;
+  sqrtPriceX96: ethers.BigNumber;
+  tick: number;
+  observationIndex: number;
+  observationCardinality: number;
+  observationCardinalityNext: number;
+  feeProtocol: number;
+  unlocked: boolean;
+}
+
+async function getPoolImmutables() {
+  const immutables: Immutables = {
+    factory: await poolContract.factory(),
+    token0: await poolContract.token0(),
+    token1: await poolContract.token1(),
+    fee: await poolContract.fee(),
+    tickSpacing: await poolContract.tickSpacing(),
+    maxLiquidityPerTick: await poolContract.maxLiquidityPerTick(),
+  };
+  return immutables;
+}
+
+async function getPoolState() {
+  const slot = await poolContract.slot0();
+  const PoolState: State = {
+    liquidity: await poolContract.liquidity(),
+    sqrtPriceX96: slot[0],
+    tick: slot[1],
+    observationIndex: slot[2],
+    observationCardinality: slot[3],
+    observationCardinalityNext: slot[4],
+    feeProtocol: slot[5],
+    unlocked: slot[6],
+  };
+  return PoolState;
+}
+
+async function main() {
+  const immutables = await getPoolImmutables();
+  const state = await getPoolState();
+  const TokenA = new Token(1, immutables.token0, 6, "USDC", "USD Coin");
+  const TokenB = new Token(1, immutables.token1, 18, "WETH", "Wrapped Ether");
+
+  const poolExample = new Pool(
+    TokenA,
+    TokenB,
+    immutables.fee,
+    state.sqrtPriceX96.toString(),
+    state.liquidity.toString(),
+    state.tick
+  );
+  console.log(poolExample);
+}
+
+main();

--- a/contracts/examples/sdkPoolExamples.ts
+++ b/contracts/examples/sdkPoolExamples.ts
@@ -1,39 +1,32 @@
+import { ethers } from 'ethers'
+import { Pool } from '@uniswap/v3-sdk'
+import { Token } from '@uniswap/sdk-core'
+import { abi as IUniswapV3PoolABI } from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json'
 
-import { ethers } from "ethers";
-import { Pool } from "@uniswap/v3-sdk";
-import { Token } from "@uniswap/sdk-core";
-import { abi as IUniswapV3PoolABI } from "@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json";
+const provider = new ethers.providers.JsonRpcProvider('https://mainnet.infura.io/v3/<YOUR-ENDPOINT-HERE>')
 
-const provider = new ethers.providers.JsonRpcProvider(
-  "https://mainnet.infura.io/v3/<YOUR-ENDPOINT-HERE>"
-);
+const poolAddress = '0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8'
 
-const poolAddress = "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8";
-
-const poolContract = new ethers.Contract(
-  poolAddress,
-  IUniswapV3PoolABI,
-  provider
-);
+const poolContract = new ethers.Contract(poolAddress, IUniswapV3PoolABI, provider)
 
 interface Immutables {
-  factory: string;
-  token0: string;
-  token1: string;
-  fee: number;
-  tickSpacing: number;
-  maxLiquidityPerTick: ethers.BigNumber;
+  factory: string
+  token0: string
+  token1: string
+  fee: number
+  tickSpacing: number
+  maxLiquidityPerTick: ethers.BigNumber
 }
 
 interface State {
-  liquidity: ethers.BigNumber;
-  sqrtPriceX96: ethers.BigNumber;
-  tick: number;
-  observationIndex: number;
-  observationCardinality: number;
-  observationCardinalityNext: number;
-  feeProtocol: number;
-  unlocked: boolean;
+  liquidity: ethers.BigNumber
+  sqrtPriceX96: ethers.BigNumber
+  tick: number
+  observationIndex: number
+  observationCardinality: number
+  observationCardinalityNext: number
+  feeProtocol: number
+  unlocked: boolean
 }
 
 async function getPoolImmutables() {
@@ -44,12 +37,12 @@ async function getPoolImmutables() {
     fee: await poolContract.fee(),
     tickSpacing: await poolContract.tickSpacing(),
     maxLiquidityPerTick: await poolContract.maxLiquidityPerTick(),
-  };
-  return immutables;
+  }
+  return immutables
 }
 
 async function getPoolState() {
-  const slot = await poolContract.slot0();
+  const slot = await poolContract.slot0()
   const PoolState: State = {
     liquidity: await poolContract.liquidity(),
     sqrtPriceX96: slot[0],
@@ -59,15 +52,15 @@ async function getPoolState() {
     observationCardinalityNext: slot[4],
     feeProtocol: slot[5],
     unlocked: slot[6],
-  };
-  return PoolState;
+  }
+  return PoolState
 }
 
 async function main() {
-  const immutables = await getPoolImmutables();
-  const state = await getPoolState();
-  const TokenA = new Token(1, immutables.token0, 6, "USDC", "USD Coin");
-  const TokenB = new Token(1, immutables.token1, 18, "WETH", "Wrapped Ether");
+  const immutables = await getPoolImmutables()
+  const state = await getPoolState()
+  const TokenA = new Token(1, immutables.token0, 6, 'USDC', 'USD Coin')
+  const TokenB = new Token(1, immutables.token1, 18, 'WETH', 'Wrapped Ether')
 
   const poolExample = new Pool(
     TokenA,
@@ -76,8 +69,8 @@ async function main() {
     state.sqrtPriceX96.toString(),
     state.liquidity.toString(),
     state.tick
-  );
-  console.log(poolExample);
+  )
+  console.log(poolExample)
 }
 
-main();
+main()


### PR DESCRIPTION
Never got this properly reviewed in the previous cycle - the goal is a first-principles example of creating a pool instance, mostly to contextualize the v3 sdk VS ethers.js

Couldn't figure out how to promise.all the correct way in `getPoolState`, could use some advice there.