### PR TITLE
On-chain Swap + Add

### DIFF
--- a/contracts/libraries/PoolTicksLibrary.sol
+++ b/contracts/libraries/PoolTicksLibrary.sol
@@ -5,14 +5,14 @@ import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import '@uniswap/v3-core/contracts/libraries/BitMath.sol';
 
 library PoolTicksLibrary {
-		/// @notice Computes the position in the mapping where the initialized bit for a tick lives
-		/// @param tick The tick for which to compute the position
-		/// @return wordPos The key in the mapping containing the word in which the bit is stored
-		/// @return bitPos The bit position in the word where the flag is stored
-		function position(int24 tick) private pure returns (int16 wordPos, uint8 bitPos) {
-				wordPos = int16(tick >> 8);
-				bitPos = uint8(tick % 256);
-		}
+    /// @notice Computes the position in the mapping where the initialized bit for a tick lives
+    /// @param tick The tick for which to compute the position
+    /// @return wordPos The key in the mapping containing the word in which the bit is stored
+    /// @return bitPos The bit position in the word where the flag is stored
+    function position(int24 tick) private pure returns (int16 wordPos, uint8 bitPos) {
+        wordPos = int16(tick >> 8);
+        bitPos = uint8(tick % 256);
+    }
 
     /// @notice Returns the next initialized tick contained in the same word (or adjacent word) as the tick that is either
     /// to the left (less than or equal to) or right (greater than) of the given tick
@@ -22,7 +22,7 @@ library PoolTicksLibrary {
     /// @param lte Whether to search for the next initialized tick to the left (less than or equal to the starting tick)
     /// @return next The next initialized or uninitialized tick up to 256 ticks away from the current tick
     /// @return initialized Whether the next tick is initialized, as the function only searches within up to 256 ticks
-		///
+    ///
     function nextInitializedTickWithinOneWord(
         IUniswapV3Pool pool,
         int24 tick,

--- a/contracts/libraries/PoolTicksLibrary.sol
+++ b/contracts/libraries/PoolTicksLibrary.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.6.0;
+
+import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
+import '@uniswap/v3-core/contracts/libraries/BitMath.sol';
+
+library PoolTicksLibrary {
+		/// @notice Computes the position in the mapping where the initialized bit for a tick lives
+		/// @param tick The tick for which to compute the position
+		/// @return wordPos The key in the mapping containing the word in which the bit is stored
+		/// @return bitPos The bit position in the word where the flag is stored
+		function position(int24 tick) private pure returns (int16 wordPos, uint8 bitPos) {
+				wordPos = int16(tick >> 8);
+				bitPos = uint8(tick % 256);
+		}
+
+    /// @notice Returns the next initialized tick contained in the same word (or adjacent word) as the tick that is either
+    /// to the left (less than or equal to) or right (greater than) of the given tick
+    /// @param pool The Uniswap pool
+    /// @param tick The starting tick
+    /// @param tickSpacing The spacing between usable ticks
+    /// @param lte Whether to search for the next initialized tick to the left (less than or equal to the starting tick)
+    /// @return next The next initialized or uninitialized tick up to 256 ticks away from the current tick
+    /// @return initialized Whether the next tick is initialized, as the function only searches within up to 256 ticks
+		///
+    function nextInitializedTickWithinOneWord(
+        IUniswapV3Pool pool,
+        int24 tick,
+        int24 tickSpacing,
+        bool lte
+    ) internal view returns (int24 next, bool initialized) {
+        int24 compressed = tick / tickSpacing;
+        if (tick < 0 && tick % tickSpacing != 0) compressed--; // round towards negative infinity
+
+        if (lte) {
+            (int16 wordPos, uint8 bitPos) = position(compressed);
+            // all the 1s at or to the right of the current bitPos
+            uint256 mask = (1 << bitPos) - 1 + (1 << bitPos);
+            uint256 masked = pool.tickBitmap(wordPos) & mask;
+
+            // if there are no initialized ticks to the right of or at the current tick, return rightmost in the word
+            initialized = masked != 0;
+            // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
+            next = initialized
+                ? (compressed - int24(bitPos - BitMath.mostSignificantBit(masked))) * tickSpacing
+                : (compressed - int24(bitPos)) * tickSpacing;
+        } else {
+            // start from the word of the next tick, since the current tick state doesn't matter
+            (int16 wordPos, uint8 bitPos) = position(compressed + 1);
+            // all the 1s at or to the left of the bitPos
+            uint256 mask = ~((1 << bitPos) - 1);
+            uint256 masked = pool.tickBitmap(wordPos) & mask;
+
+            // if there are no initialized ticks to the left of the current tick, return leftmost in the word
+            initialized = masked != 0;
+            // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
+            next = initialized
+                ? (compressed + 1 + int24(BitMath.leastSignificantBit(masked) - bitPos)) * tickSpacing
+                : (compressed + 1 + int24(type(uint8).max - bitPos)) * tickSpacing;
+        }
+    }
+}

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -1,7 +1,16 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.7.0;
 
+import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
+import '@uniswap/v3-core/contracts/libraries/SqrtPriceMath.sol';
+import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';
+import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
+import './PoolTicksLibrary.sol';
+
 library SwapToRatio {
+    using SafeCast for uint256;
+    using PoolTicksLibrary for IUniswapV3Pool;
+
     struct PoolParams {
         uint160 sqrtRatioX96;
         uint128 liquidity;
@@ -14,11 +23,67 @@ library SwapToRatio {
         uint256 amount1Desired;
     }
 
-    function amountToSwap(PoolParams calldata poolParams, PositionParams calldata positionParms)
+    function getPostSwapPrice(PoolParams memory poolParams, PositionParams memory positionParms)
         internal
         pure
         returns (uint160 postSwapSqrtRatioX96)
     {
-				// stuff
-		}
+        // given liquidty / current price / bounds / initialAmounts - calculate how much the price should move
+        // so that the token ratios are of equal liquidity.
+    }
+
+    function swapToRatio(IUniswapV3Pool pool, PositionParams memory positionParams)
+        internal
+        view
+        returns (uint160 postSwapSqrtRatioX96)
+    {
+        (uint160 sqrtRatioX96, int24 tick, , , , , ) = pool.slot0();
+        int24 tickSpacing = pool.tickSpacing();
+
+        PoolParams memory poolParams;
+        poolParams.sqrtRatioX96 = sqrtRatioX96;
+        poolParams.liquidity = pool.liquidity();
+
+        bool zeroForOne;
+        int24 nextInitializedTick;
+        bool crossedTickBoundary = true; // TODO: awkward naming since this doesn't reeeeally start out as true
+
+        while (crossedTickBoundary) {
+            postSwapSqrtRatioX96 = getPostSwapPrice(poolParams, positionParams);
+            zeroForOne = postSwapSqrtRatioX96 < poolParams.sqrtRatioX96;
+
+            // returns the next initialized tick or the last tick within one word of the current tick
+            // will renew calculation at least on a per word basis for better rounding
+            (nextInitializedTick,) = pool.nextInitializedTickWithinOneWord(tick, tickSpacing, zeroForOne);
+
+            crossedTickBoundary = zeroForOne
+                ? postSwapSqrtRatioX96 <= TickMath.getSqrtRatioAtTick(nextInitializedTick)
+                : postSwapSqrtRatioX96 >= TickMath.getSqrtRatioAtTick(nextInitializedTick);
+
+            if (crossedTickBoundary) {
+                // if crossing tick, get token amounts at crossed tick
+                // then run getPostSwapPrice with new amounts + new liquidity + new sqrtRatioX96
+                int256 amount0Delta =
+                    SqrtPriceMath.getAmount0Delta(
+                        postSwapSqrtRatioX96,
+                        TickMath.getSqrtRatioAtTick(nextInitializedTick),
+                        zeroForOne ? int128(-poolParams.liquidity) : int128(poolParams.liquidity)
+                    );
+                int256 amount1Delta =
+                    SqrtPriceMath.getAmount1Delta(
+                        postSwapSqrtRatioX96,
+                        TickMath.getSqrtRatioAtTick(nextInitializedTick),
+                        zeroForOne ? int128(poolParams.liquidity) : int128(-poolParams.liquidity)
+                    );
+                (, int128 liquidityNet, , , , , , ) = pool.ticks(nextInitializedTick);
+
+                // overflow desired, but open to better ways to do the addition/subtraction
+                positionParams.amount0Desired += uint256(amount0Delta);
+                positionParams.amount1Desired += uint256(amount1Delta);
+                poolParams.sqrtRatioX96 = postSwapSqrtRatioX96;
+                poolParams.liquidity += uint128(liquidityNet);
+                tick = nextInitializedTick;
+            }
+        }
+    }
 }

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -33,7 +33,7 @@ library SwapToRatio {
 
     // TODO: Look into rounding things correctly
     // TODO: know exact price to change liquidity at (liquidity changes right of initialized tick?)
-    function swapToNextTick(
+    function swapToNextInitializedTick(
         PoolParams memory poolParams,
         PositionParams memory positionParams,
         uint160 sqrtRatioX96Target,
@@ -99,6 +99,8 @@ library SwapToRatio {
         }
     }
 
+
+    // TODO: address range order scenarios
     function getPostSwapPrice(IUniswapV3Pool pool, PositionParams memory positionParams)
         internal
         view
@@ -119,12 +121,12 @@ library SwapToRatio {
         int24 nextInitializedTick;
 
         while (crossTickBoundary) {
-            // returns the next initialized tick or the last tick within one word of the current tick
-            // will renew calculation at least on a per word basis for better rounding
+            // returns the next initialized tick or the last tick within one word of the current tick.
+            // We'll renew calculation at least on a per word basis for better rounding
             (nextInitializedTick, ) = pool.nextInitializedTickWithinOneWord(tick, tickSpacing, zeroForOne);
             uint160 sqrtRatioNextX96 = TickMath.getSqrtRatioAtTick(nextInitializedTick);
 
-            (crossTickBoundary, amount0Next, amount1Next) = swapToNextTick(
+            (crossTickBoundary, amount0Next, amount1Next) = swapToNextInitializedTick(
                 poolParams,
                 positionParams,
                 sqrtRatioNextX96,

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -87,6 +87,7 @@ library SwapToRatio {
 
         // overflow desired
         if (zeroForOne) {
+            // include fee amount in token delta for exchanged token
             amount0Updated = positionParams.amount0Initial + uint256(((token0Delta * 1e6) / (1e6 - poolParams.fee)));
             amount1Updated = positionParams.amount1Initial + uint256(token1Delta);
             // 1e5 to increase precision for small price differences

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -32,7 +32,6 @@ library SwapToRatio {
         // will switch from quadratic to binary search
     }
 
-
     function swapToNextInitializedTick(
         PoolParams memory poolParams,
         PositionParams memory positionParams,

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -29,11 +29,10 @@ library SwapToRatio {
     ) internal pure returns (uint160 postSwapSqrtRatioX96) {
         // given constant liquidty / current price / bounds / initialAmounts - calculate how much the price should move
         // so that the token ratios are of equal liquidity.
-        // will switch from quadratic to binary search :(
+        // will switch from quadratic to binary search
     }
 
-    // TODO: Look into rounding things correctly
-    // TODO: know exact price to change liquidity at (liquidity changes right of initialized tick?)
+
     function swapToNextInitializedTick(
         PoolParams memory poolParams,
         PositionParams memory positionParams,
@@ -88,7 +87,6 @@ library SwapToRatio {
                 false
             );
 
-        // overflow desired
         if (zeroForOne) {
             // include fee amount in token delta for exchanged token
             amount0Updated = positionParams.amount0Initial - ((token0Delta * 1e6) / (1e6 - poolParams.fee));

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -47,6 +47,16 @@ library SwapToRatio {
             uint256 amount1Updated
         )
     {
+        if (zeroForOne) {
+          if (sqrtRatioX96Target < positionParams.sqrtRatioX96Lower) {
+            return (false, 0, 0);
+          }
+        } else {
+          if (sqrtRatioX96Target > positionParams.sqrtRatioX96Upper) {
+            return (false, 0, 0);
+          }
+        }
+
         int256 token0Delta =
             SqrtPriceMath.getAmount0Delta(
                 poolParams.sqrtRatioX96,
@@ -79,7 +89,7 @@ library SwapToRatio {
         if (zeroForOne) {
             amount0Updated = positionParams.amount0Initial + uint256(((token0Delta * 1e6) / (1e6 - poolParams.fee)));
             amount1Updated = positionParams.amount1Initial + uint256(token1Delta);
-            // 1e5 to increase precision for small numbers
+            // 1e5 to increase precision for small price differences
             doSwap = (amount0Updated * 1e5) / amount1Updated >= (validDeposit0 * 1e5) / validDeposit1;
         } else {
             amount0Updated = positionParams.amount0Initial + uint256(token0Delta);

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.7.0;
+
+library SwapToRatio {
+    struct PoolParams {
+        uint160 sqrtRatioX96;
+        uint128 liquidity;
+    }
+
+    struct PositionParams {
+        uint160 sqrtRatioX96Lower;
+        uint160 sqrtRatioX96Upper;
+        uint256 amount0Desired;
+        uint256 amount1Desired;
+    }
+
+    function amountToSwap(PoolParams calldata poolParams, PositionParams calldata positionParms)
+        internal
+        pure
+        returns (uint160 postSwapSqrtRatioX96)
+    {
+				// stuff
+		}
+}

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -48,13 +48,13 @@ library SwapToRatio {
         )
     {
         if (zeroForOne) {
-          if (sqrtRatioX96Target < positionParams.sqrtRatioX96Lower) {
-            return (false, 0, 0);
-          }
+            if (sqrtRatioX96Target < positionParams.sqrtRatioX96Lower) {
+                return (false, 0, 0);
+            }
         } else {
-          if (sqrtRatioX96Target > positionParams.sqrtRatioX96Upper) {
-            return (false, 0, 0);
-          }
+            if (sqrtRatioX96Target > positionParams.sqrtRatioX96Upper) {
+                return (false, 0, 0);
+            }
         }
 
         int256 token0Delta =

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -29,6 +29,8 @@ library SwapToRatio {
     ) internal pure returns (uint160 postSwapSqrtRatioX96) {
         // given constant liquidty / current price / bounds / initialAmounts - calculate how much the price should move
         // so that the token ratios are of equal liquidity.
+
+        // will switch from quadratic to binary search :(
     }
 
     // TODO: Look into rounding things correctly
@@ -154,37 +156,18 @@ library SwapToRatio {
         uint160 sqrtRatioX96,
         uint160 sqrtRatioX96Lower,
         uint160 sqrtRatioX96Upper
-    ) private pure returns (bool) {
+    ) internal view returns (bool) {
         if (amount0 > amount1) {
             return
                 amount0 / amount1 >
-                SqrtPriceMath.getAmount0Delta(
-                    sqrtRatioX96,
-                    sqrtRatioX96Upper,
-                    1e6, // arbitrary since it cancels out
-                    false
-                ) /
-                    SqrtPriceMath.getAmount1Delta(
-                        sqrtRatioX96,
-                        sqrtRatioX96Lower,
-                        1e6,
-                        false
-                    );
+                // arbitrary liquidity param of 100_000 since it cancels out
+                SqrtPriceMath.getAmount0Delta(sqrtRatioX96, sqrtRatioX96Upper, 100_000, false) /
+                    SqrtPriceMath.getAmount1Delta(sqrtRatioX96, sqrtRatioX96Lower, 100_000, false);
         } else {
             return
-                amount1 / amount0 >
-                SqrtPriceMath.getAmount1Delta(
-                    sqrtRatioX96,
-                    sqrtRatioX96Lower,
-                    1e6,
-                    false
-                ) /
-                    SqrtPriceMath.getAmount0Delta(
-                        sqrtRatioX96,
-                        sqrtRatioX96Upper,
-                        1e6,
-                        false
-                    );
+                amount1 / amount0 <
+                SqrtPriceMath.getAmount1Delta(sqrtRatioX96, sqrtRatioX96Lower, 100_000, false) /
+                    SqrtPriceMath.getAmount0Delta(sqrtRatioX96, sqrtRatioX96Upper, 100_000, false);
         }
     }
 

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -5,6 +5,7 @@ import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
 import '@uniswap/v3-core/contracts/libraries/SqrtPriceMath.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import './PoolTicksLibrary.sol';
+import 'hardhat/console.sol';
 
 library SwapToRatio {
     using PoolTicksLibrary for IUniswapV3Pool;
@@ -22,15 +23,70 @@ library SwapToRatio {
         uint256 amount1Initial;
     }
 
-    function calculateConstantLiquidityPostSwapPrice(PoolParams memory poolParams, PositionParams memory positionParms)
-        internal
-        pure
-        returns (uint160 postSwapSqrtRatioX96)
-    {
+    function calculateConstantLiquidityPostSwapSqrtPrice(
+        PoolParams memory poolParams,
+        PositionParams memory positionParms
+    ) internal pure returns (uint160 postSwapSqrtRatioX96) {
         // given constant liquidty / current price / bounds / initialAmounts - calculate how much the price should move
         // so that the token ratios are of equal liquidity.
     }
 
+    // TODO: Current solving for token1 only
+    function tradeToNextTick(
+        PoolParams memory poolParams,
+        PositionParams memory positionParams,
+        uint160 sqrtRatioX96Target,
+        bool zeroForOne
+    ) internal view returns (bool) {
+        int256 token0Delta =
+            SqrtPriceMath.getAmount0Delta(poolParams.sqrtRatioX96, sqrtRatioX96Target, int128(poolParams.liquidity));
+        int256 token1Delta =
+            int256(SqrtPriceMath.getAmount1Delta(poolParams.sqrtRatioX96, sqrtRatioX96Target, int128(poolParams.liquidity)));
+        uint256 amount1InitialLessFee =
+            FullMath.mulDiv(uint256(positionParams.amount1Initial), 1e6 - poolParams.fee, 1e6);
+
+        console.logInt(token0Delta);
+        console.log(uint256(token0Delta));
+        console.logInt(token1Delta);
+        console.log(amount1InitialLessFee);
+
+        /* uint256 ratioValidDeposit = uint256(-token1Delta) / uint256(token0Delta);
+        uint256 ratioAvailableToDeposit =
+            (positionParams.amount1Initial + uint256(token1Delta) * (positionParams.amount1Initial / amount1InitialLessFee)) /
+                (positionParams.amount0Initial + token0Delta); */
+/*
+        console.log(ratioValidDeposit);
+        console.log(ratioAvailableToDeposit); */
+
+        return false;
+
+        /* return ratioValidDeposit < ratioAvailableToDeposit; */
+    }
+
+    // TODO: this function is still in rough shape atm
+    function getPostSwapPrice(IUniswapV3Pool pool, PositionParams memory positionParams)
+        internal
+        view
+        returns (uint160 postSwapSqrtRatioX96)
+    {
+        (uint160 sqrtRatioX96, int24 tick, , , , , ) = pool.slot0();
+        int24 tickSpacing = pool.tickSpacing();
+        uint24 fee = pool.fee();
+
+        PoolParams memory poolParams = PoolParams({sqrtRatioX96: sqrtRatioX96, liquidity: pool.liquidity(), fee: fee});
+
+        bool zeroForOne =
+            SqrtPriceMath.getAmount0Delta(
+                poolParams.sqrtRatioX96,
+                positionParams.sqrtRatioX96Upper,
+                poolParams.liquidity,
+                false
+            ) < positionParams.amount0Initial;
+
+        return 5;
+    }
+
+    /* // TODO: this function is still in rough shape atm
     function getPostSwapPrice(IUniswapV3Pool pool, PositionParams memory positionParams)
         internal
         view
@@ -46,8 +102,10 @@ library SwapToRatio {
         int24 nextInitializedTick;
         bool crossedTickBoundary = true; // TODO: awkward naming since this doesn't reeeeally start out as true
 
+        // first
+
         while (crossedTickBoundary) {
-            postSwapSqrtRatioX96 = calculateConstantLiquidityPostSwapPrice(poolParams, positionParams);
+            postSwapSqrtRatioX96 = calculateConstantLiquidityPostSwapSqrtPrice(poolParams, positionParams);
             zeroForOne = postSwapSqrtRatioX96 < poolParams.sqrtRatioX96;
 
             // returns the next initialized tick or the last tick within one word of the current tick
@@ -83,5 +141,5 @@ library SwapToRatio {
                 tick = nextInitializedTick;
             }
         }
-    }
+    } */
 }

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -109,6 +109,8 @@ library SwapToRatio {
     {
         (PoolParams memory poolParams, int24 tickSpacing, int24 tick) = getPoolInputs(pool);
 
+        console.logInt(tick);
+
         bool zeroForOne =
             isZeroForOne(
                 positionParams.amount0Initial,
@@ -121,12 +123,13 @@ library SwapToRatio {
         uint256 amount0Next;
         uint256 amount1Next;
         int24 nextInitializedTick;
+        uint160 sqrtRatioNextX96;
 
         while (crossTickBoundary) {
             // returns the next initialized tick or the last tick within one word of the current tick.
             // We'll renew calculation at least on a per word basis for better rounding
             (nextInitializedTick, ) = pool.nextInitializedTickWithinOneWord(tick, tickSpacing, zeroForOne);
-            uint160 sqrtRatioNextX96 = TickMath.getSqrtRatioAtTick(nextInitializedTick);
+            sqrtRatioNextX96 = TickMath.getSqrtRatioAtTick(nextInitializedTick);
 
             (crossTickBoundary, amount0Next, amount1Next) = swapToNextInitializedTick(
                 poolParams,
@@ -147,7 +150,9 @@ library SwapToRatio {
                 tick = nextInitializedTick;
             }
         }
-        return calculateConstantLiquidityPostSwapSqrtPrice(poolParams, positionParams);
+        return sqrtRatioNextX96;
+        // TODO: return calculateConstantLiquidityPostSwapSqrtPrice
+        // return calculateConstantLiquidityPostSwapSqrtPrice(poolParams, positionParams);
     }
 
     function isZeroForOne(

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -107,8 +107,6 @@ library SwapToRatio {
     {
         (PoolParams memory poolParams, int24 tickSpacing, int24 tick) = getPoolInputs(pool);
 
-        console.logInt(tick);
-
         bool zeroForOne =
             isZeroForOne(
                 positionParams.amount0Initial,

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -54,7 +54,7 @@ library SwapToRatio {
 
             // returns the next initialized tick or the last tick within one word of the current tick
             // will renew calculation at least on a per word basis for better rounding
-            (nextInitializedTick,) = pool.nextInitializedTickWithinOneWord(tick, tickSpacing, zeroForOne);
+            (nextInitializedTick, ) = pool.nextInitializedTickWithinOneWord(tick, tickSpacing, zeroForOne);
 
             crossedTickBoundary = zeroForOne
                 ? postSwapSqrtRatioX96 <= TickMath.getSqrtRatioAtTick(nextInitializedTick)

--- a/contracts/libraries/SwapToRatio.sol
+++ b/contracts/libraries/SwapToRatio.sol
@@ -3,53 +3,51 @@ pragma solidity >=0.7.0;
 
 import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
 import '@uniswap/v3-core/contracts/libraries/SqrtPriceMath.sol';
-import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import './PoolTicksLibrary.sol';
 
 library SwapToRatio {
-    using SafeCast for uint256;
     using PoolTicksLibrary for IUniswapV3Pool;
 
     struct PoolParams {
         uint160 sqrtRatioX96;
         uint128 liquidity;
+        uint24 fee;
     }
 
     struct PositionParams {
         uint160 sqrtRatioX96Lower;
         uint160 sqrtRatioX96Upper;
-        uint256 amount0Desired;
-        uint256 amount1Desired;
+        uint256 amount0Initial;
+        uint256 amount1Initial;
     }
 
-    function getPostSwapPrice(PoolParams memory poolParams, PositionParams memory positionParms)
+    function calculateConstantLiquidityPostSwapPrice(PoolParams memory poolParams, PositionParams memory positionParms)
         internal
         pure
         returns (uint160 postSwapSqrtRatioX96)
     {
-        // given liquidty / current price / bounds / initialAmounts - calculate how much the price should move
+        // given constant liquidty / current price / bounds / initialAmounts - calculate how much the price should move
         // so that the token ratios are of equal liquidity.
     }
 
-    function swapToRatio(IUniswapV3Pool pool, PositionParams memory positionParams)
+    function getPostSwapPrice(IUniswapV3Pool pool, PositionParams memory positionParams)
         internal
         view
         returns (uint160 postSwapSqrtRatioX96)
     {
         (uint160 sqrtRatioX96, int24 tick, , , , , ) = pool.slot0();
         int24 tickSpacing = pool.tickSpacing();
+        uint24 fee = pool.fee();
 
-        PoolParams memory poolParams;
-        poolParams.sqrtRatioX96 = sqrtRatioX96;
-        poolParams.liquidity = pool.liquidity();
+        PoolParams memory poolParams = PoolParams({sqrtRatioX96: sqrtRatioX96, liquidity: pool.liquidity(), fee: fee});
 
         bool zeroForOne;
         int24 nextInitializedTick;
         bool crossedTickBoundary = true; // TODO: awkward naming since this doesn't reeeeally start out as true
 
         while (crossedTickBoundary) {
-            postSwapSqrtRatioX96 = getPostSwapPrice(poolParams, positionParams);
+            postSwapSqrtRatioX96 = calculateConstantLiquidityPostSwapPrice(poolParams, positionParams);
             zeroForOne = postSwapSqrtRatioX96 < poolParams.sqrtRatioX96;
 
             // returns the next initialized tick or the last tick within one word of the current tick
@@ -58,7 +56,7 @@ library SwapToRatio {
 
             crossedTickBoundary = zeroForOne
                 ? postSwapSqrtRatioX96 <= TickMath.getSqrtRatioAtTick(nextInitializedTick)
-                : postSwapSqrtRatioX96 >= TickMath.getSqrtRatioAtTick(nextInitializedTick);
+                : postSwapSqrtRatioX96 > TickMath.getSqrtRatioAtTick(nextInitializedTick);
 
             if (crossedTickBoundary) {
                 // if crossing tick, get token amounts at crossed tick
@@ -78,8 +76,8 @@ library SwapToRatio {
                 (, int128 liquidityNet, , , , , , ) = pool.ticks(nextInitializedTick);
 
                 // overflow desired, but open to better ways to do the addition/subtraction
-                positionParams.amount0Desired += uint256(amount0Delta);
-                positionParams.amount1Desired += uint256(amount1Delta);
+                positionParams.amount0Initial += uint256(amount0Delta);
+                positionParams.amount1Initial += uint256(amount1Delta);
                 poolParams.sqrtRatioX96 = postSwapSqrtRatioX96;
                 poolParams.liquidity += uint128(liquidityNet);
                 tick = nextInitializedTick;

--- a/contracts/test/SwapToRatioTest.sol
+++ b/contracts/test/SwapToRatioTest.sol
@@ -13,7 +13,7 @@ contract SwapToRatioTest {
         return SwapToRatio.getPostSwapPrice(pool, positionParams);
     }
 
-    function swapToNextTick(
+    function swapToNextInitializedTick(
         SwapToRatio.PoolParams memory poolParams,
         SwapToRatio.PositionParams memory positionParams,
         uint160 sqrtRatioX96Target,
@@ -27,6 +27,6 @@ contract SwapToRatioTest {
             uint256
         )
     {
-        return SwapToRatio.swapToNextTick(poolParams, positionParams, sqrtRatioX96Target, zeroForOne);
+        return SwapToRatio.swapToNextInitializedTick(poolParams, positionParams, sqrtRatioX96Target, zeroForOne);
     }
 }

--- a/contracts/test/SwapToRatioTest.sol
+++ b/contracts/test/SwapToRatioTest.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.7.6;
+
+import '../libraries/SwapToRatio.sol';
+
+contract SwapToRatioTest {
+    function getPostSwapPrice(IUniswapV3Pool pool, SwapToRatio.PositionParams memory positionParams)
+        internal
+        view
+        returns (uint160)
+    {
+        return SwapToRatio.getPostSwapPrice(pool, positionParams);
+    }
+}

--- a/contracts/test/SwapToRatioTest.sol
+++ b/contracts/test/SwapToRatioTest.sol
@@ -13,13 +13,20 @@ contract SwapToRatioTest {
         return SwapToRatio.getPostSwapPrice(pool, positionParams);
     }
 
-    function tradeToNextTick(
+    function swapToNextTick(
         SwapToRatio.PoolParams memory poolParams,
         SwapToRatio.PositionParams memory positionParams,
         uint160 sqrtRatioX96Target,
         bool zeroForOne
-    ) external view returns (bool)
+    )
+        external
+        view
+        returns (
+            bool,
+            uint256,
+            uint256
+        )
     {
-      return SwapToRatio.tradeToNextTick(poolParams, positionParams, sqrtRatioX96Target, zeroForOne);
+        return SwapToRatio.swapToNextTick(poolParams, positionParams, sqrtRatioX96Target, zeroForOne);
     }
 }

--- a/contracts/test/SwapToRatioTest.sol
+++ b/contracts/test/SwapToRatioTest.sol
@@ -4,7 +4,7 @@ pragma abicoder v2;
 
 import '../libraries/SwapToRatio.sol';
 import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
-
+import '@uniswap/v3-core/contracts/libraries/SqrtPriceMath.sol';
 
 contract SwapToRatioTest {
     function getPostSwapPrice(IUniswapV3Pool pool, SwapToRatio.PositionParams memory positionParams)
@@ -32,8 +32,17 @@ contract SwapToRatioTest {
         return SwapToRatio.swapToNextInitializedTick(poolParams, positionParams, sqrtRatioX96Target, zeroForOne);
     }
 
-    // helpful for conversion during test
+    // extra helper functions for tests
     function getSqrtRatioAtTick(int24 tick) external pure returns (uint160) {
-      return TickMath.getSqrtRatioAtTick(tick);
+        return TickMath.getSqrtRatioAtTick(tick);
+    }
+
+    function getAmount0Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint128 liquidity,
+        bool roundUp
+    ) external pure returns (uint256) {
+        return SqrtPriceMath.getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, liquidity, roundUp);
     }
 }

--- a/contracts/test/SwapToRatioTest.sol
+++ b/contracts/test/SwapToRatioTest.sol
@@ -43,6 +43,13 @@ contract SwapToRatioTest {
         return gasBefore - gasleft();
     }
 
+    function getPostSwapPriceGas(IUniswapV3Pool pool, SwapToRatio.PositionParams memory positionParams)
+      external view returns (uint256) {
+        uint256 gasBefore = gasleft();
+        SwapToRatio.getPostSwapPrice(pool, positionParams);
+        return gasBefore - gasleft();
+    }
+
     // extra helper functions for tests
     function getSqrtRatioAtTick(int24 tick) external pure returns (uint160) {
         return TickMath.getSqrtRatioAtTick(tick);

--- a/contracts/test/SwapToRatioTest.sol
+++ b/contracts/test/SwapToRatioTest.sol
@@ -44,7 +44,10 @@ contract SwapToRatioTest {
     }
 
     function getPostSwapPriceGas(IUniswapV3Pool pool, SwapToRatio.PositionParams memory positionParams)
-      external view returns (uint256) {
+        external
+        view
+        returns (uint256)
+    {
         uint256 gasBefore = gasleft();
         SwapToRatio.getPostSwapPrice(pool, positionParams);
         return gasBefore - gasleft();
@@ -62,5 +65,14 @@ contract SwapToRatioTest {
         bool roundUp
     ) external pure returns (uint256) {
         return SqrtPriceMath.getAmount0Delta(sqrtRatioAX96, sqrtRatioBX96, liquidity, roundUp);
+    }
+
+    function getAmount1Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint128 liquidity,
+        bool roundUp
+    ) external pure returns (uint256) {
+        return SqrtPriceMath.getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, liquidity, roundUp);
     }
 }

--- a/contracts/test/SwapToRatioTest.sol
+++ b/contracts/test/SwapToRatioTest.sol
@@ -32,6 +32,17 @@ contract SwapToRatioTest {
         return SwapToRatio.swapToNextInitializedTick(poolParams, positionParams, sqrtRatioX96Target, zeroForOne);
     }
 
+    function swapToNextInitializedTickGas(
+        SwapToRatio.PoolParams memory poolParams,
+        SwapToRatio.PositionParams memory positionParams,
+        uint160 sqrtRatioX96Target,
+        bool zeroForOne
+    ) external view returns (uint256) {
+        uint256 gasBefore = gasleft();
+        SwapToRatio.swapToNextInitializedTick(poolParams, positionParams, sqrtRatioX96Target, zeroForOne);
+        return gasBefore - gasleft();
+    }
+
     // extra helper functions for tests
     function getSqrtRatioAtTick(int24 tick) external pure returns (uint160) {
         return TickMath.getSqrtRatioAtTick(tick);

--- a/contracts/test/SwapToRatioTest.sol
+++ b/contracts/test/SwapToRatioTest.sol
@@ -3,6 +3,8 @@ pragma solidity =0.7.6;
 pragma abicoder v2;
 
 import '../libraries/SwapToRatio.sol';
+import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
+
 
 contract SwapToRatioTest {
     function getPostSwapPrice(IUniswapV3Pool pool, SwapToRatio.PositionParams memory positionParams)
@@ -28,5 +30,10 @@ contract SwapToRatioTest {
         )
     {
         return SwapToRatio.swapToNextInitializedTick(poolParams, positionParams, sqrtRatioX96Target, zeroForOne);
+    }
+
+    // helpful for conversion during test
+    function getSqrtRatioAtTick(int24 tick) external pure returns (uint160) {
+      return TickMath.getSqrtRatioAtTick(tick);
     }
 }

--- a/contracts/test/SwapToRatioTest.sol
+++ b/contracts/test/SwapToRatioTest.sol
@@ -1,14 +1,25 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.7.6;
+pragma abicoder v2;
 
 import '../libraries/SwapToRatio.sol';
 
 contract SwapToRatioTest {
     function getPostSwapPrice(IUniswapV3Pool pool, SwapToRatio.PositionParams memory positionParams)
-        internal
+        external
         view
         returns (uint160)
     {
         return SwapToRatio.getPostSwapPrice(pool, positionParams);
+    }
+
+    function tradeToNextTick(
+        SwapToRatio.PoolParams memory poolParams,
+        SwapToRatio.PositionParams memory positionParams,
+        uint160 sqrtRatioX96Target,
+        bool zeroForOne
+    ) external view returns (bool)
+    {
+      return SwapToRatio.tradeToNextTick(poolParams, positionParams, sqrtRatioX96Target, zeroForOne);
     }
 }

--- a/test/SwapToRatioTest.spec.ts
+++ b/test/SwapToRatioTest.spec.ts
@@ -156,9 +156,9 @@ describe.only('SwapToRatio', () => {
       })
     })
 
-    describe.only('when initial deposit has excess of token0', () => {
-      it.only('returns the correct postSqrtPrice when it is just below the next initialized tick', async () => {
-        
+    describe('when initial deposit has excess of token0', () => {
+      it('returns the correct postSqrtPrice when it is just below the next initialized tick', async () => {
+
       })
       it('returns the correct postSqrtPrice when it corresponds exactly with the next initialized tick')
       it('returns the correct postSqrtPrice when it is just above the next initialized tick')
@@ -200,7 +200,7 @@ describe.only('SwapToRatio', () => {
     })
   })
 
-  describe.only('#swapToNextInitializedTick', () => {
+  describe('#swapToNextInitializedTick', () => {
     // position params
     let amount0Initial: BigNumberish
     let amount1Initial: BigNumberish

--- a/test/SwapToRatioTest.spec.ts
+++ b/test/SwapToRatioTest.spec.ts
@@ -1,0 +1,77 @@
+import { constants } from 'ethers'
+import { waffle, ethers } from 'hardhat'
+import { Fixture } from 'ethereum-waffle'
+import { SwapToRatioTest } from '../typechain'
+import { expect } from 'chai'
+
+describe('SwapToRatio', () => {
+  const [...wallets] = waffle.provider.getWallets()
+  const positionValueCompleteFixture: Fixture<{
+    swapToRatio: SwapToRatioTest
+    tokens: [TestERC20, TestERC20, TestERC20]
+    nft: MockTimeNonfungiblePositionManager
+    router: SwapRouter
+  }> = async (wallets, provider) => {
+    const { nft, router, tokens } = await completeFixture(wallets, provider)
+    const positionValueFactory = await ethers.getContractFactory('PositionValueTest')
+    const positionValue = (await positionValueFactory.deploy()) as PositionValueTest
+
+    for (const token of tokens) {
+      await token.approve(nft.address, constants.MaxUint256)
+      await token.connect(wallets[0]).approve(nft.address, constants.MaxUint256)
+      await token.transfer(wallets[0].address, expandTo18Decimals(1_000_000))
+    }
+
+    return {
+      positionValue,
+      tokens,
+      nft,
+      router,
+    }
+  }
+
+  let tokens: [TestERC20, TestERC20, TestERC20]
+  let swapToRatioTest: SwapToRatioTest
+  let nft: MockTimeNonfungiblePositionManager
+  let router: SwapRouter
+
+  const amountDesired = 100
+
+  describe('#getPostSwapPrice ', () => {
+    describe('when initial deposit has excess of token0', () => {
+      describe('and swap does not push price beyond the next initialized tick', () => {
+        // it returns the correct postSqrtPrice for various values
+      })
+
+      describe('and swap pushes the price beyond the next initialized tick', () => {
+        // it returns the correct postSqrtPrice for various values
+      })
+
+      describe('and swap pushes the price beyond multiple initialized ticks', () => {
+        // it returns the correct postSqrtPrice for various values
+      })
+
+      it('returns the correct postSqrtPrice when it is just below the next initialized tick')
+      it('returns the correct postSqrtPrice when it corresponds exactly with the next initialized tick')
+      it('returns the correct postSqrtPrice when it is just above the next initialized tick')
+    })
+
+    describe('when initial deposit has excess of token1', () => {
+      describe('and swap does not push price beyond the next initialized tick', () => {
+        // it returns the correct postSqrtPrice for various values
+      })
+
+      describe('and swap pushes the price beyond the next initialized tick', () => {
+        // it returns the correct postSqrtPrice for various values
+      })
+
+      describe('and swap pushes the price beyond multiple initialized ticks', () => {
+        // it returns the correct postSqrtPrice for various values
+      })
+
+      it('returns the correct postSqrtPrice when it is just below the next initialized tick')
+      it('returns the correct postSqrtPrice when it corresponds exactly with the next initialized tick')
+      it('returns the correct postSqrtPrice when it is just above the next initialized tick')
+    })
+  })
+})

--- a/test/SwapToRatioTest.spec.ts
+++ b/test/SwapToRatioTest.spec.ts
@@ -1,20 +1,63 @@
-import { constants } from 'ethers'
+import { BigNumber, BigNumberish, constants } from 'ethers'
 import { waffle, ethers } from 'hardhat'
 import { Fixture } from 'ethereum-waffle'
-import { SwapToRatioTest } from '../typechain'
+import { SwapToRatioTest, TestERC20, MockTimeNonfungiblePositionManager, SwapRouter } from '../typechain'
 import { expect } from 'chai'
+import { expandTo18Decimals } from './shared/expandTo18Decimals'
+import completeFixture from './shared/completeFixture'
 
-describe('SwapToRatio', () => {
+const toFixedPoint96 = (n: BigNumberish): BigNumberish => {
+  return BigNumber.from(n).mul(BigNumber.from(2).pow(96))
+}
+
+type tradeToNextTickArgs = {
+  sqrtPrice: BigNumberish
+  liquidity: BigNumberish
+  fee: BigNumberish
+  sqrtPriceLower: BigNumberish
+  sqrtPriceUpper: BigNumberish
+  amount0Initial: BigNumberish
+  amount1Initial: BigNumberish
+  sqrtPriceTarget: BigNumberish
+  zeroForOne: boolean
+}
+
+async function tradeToNextTick(swapToRatio: SwapToRatioTest, args: tradeToNextTickArgs): Promise<boolean> {
+  const {
+    sqrtPrice,
+    liquidity,
+    fee,
+    sqrtPriceLower,
+    sqrtPriceUpper,
+    amount0Initial,
+    amount1Initial,
+    sqrtPriceTarget,
+    zeroForOne,
+  } = args
+  const sqrtRatioX96 = toFixedPoint96(sqrtPrice)
+  const sqrtRatioX96Lower = toFixedPoint96(sqrtPriceLower)
+  const sqrtRatioX96Upper = toFixedPoint96(sqrtPriceUpper)
+  const sqrtRatioX96Target = toFixedPoint96(sqrtPriceTarget)
+  return swapToRatio.tradeToNextTick(
+    { sqrtRatioX96, liquidity, fee },
+    { sqrtRatioX96Lower, sqrtRatioX96Upper, amount0Initial, amount1Initial },
+    sqrtRatioX96Target,
+    zeroForOne
+  )
+}
+
+describe.only('SwapToRatio', () => {
   const [...wallets] = waffle.provider.getWallets()
-  const positionValueCompleteFixture: Fixture<{
+
+  const swapToRatioCompleteFixture: Fixture<{
     swapToRatio: SwapToRatioTest
     tokens: [TestERC20, TestERC20, TestERC20]
     nft: MockTimeNonfungiblePositionManager
     router: SwapRouter
   }> = async (wallets, provider) => {
     const { nft, router, tokens } = await completeFixture(wallets, provider)
-    const positionValueFactory = await ethers.getContractFactory('PositionValueTest')
-    const positionValue = (await positionValueFactory.deploy()) as PositionValueTest
+    const swapToRatioFactory = await ethers.getContractFactory('SwapToRatioTest')
+    const swapToRatio = (await swapToRatioFactory.deploy()) as SwapToRatioTest
 
     for (const token of tokens) {
       await token.approve(nft.address, constants.MaxUint256)
@@ -23,19 +66,30 @@ describe('SwapToRatio', () => {
     }
 
     return {
-      positionValue,
+      swapToRatio,
       tokens,
       nft,
       router,
     }
   }
 
+  const swapToRatioPartialFixture: Fixture<SwapToRatioTest> = async (wallets, provider) => {
+    const swapToRatioFactory = await ethers.getContractFactory('SwapToRatioTest')
+    const swapToRatio = (await swapToRatioFactory.deploy()) as SwapToRatioTest
+    return swapToRatio
+  }
+
   let tokens: [TestERC20, TestERC20, TestERC20]
-  let swapToRatioTest: SwapToRatioTest
+  let swapToRatio: SwapToRatioTest
   let nft: MockTimeNonfungiblePositionManager
   let router: SwapRouter
 
   const amountDesired = 100
+
+  let loadFixture: ReturnType<typeof waffle.createFixtureLoader>
+  before('create fixture loader', async () => {
+    loadFixture = waffle.createFixtureLoader(wallets)
+  })
 
   describe('#getPostSwapPrice ', () => {
     describe('when initial deposit has excess of token0', () => {
@@ -54,6 +108,7 @@ describe('SwapToRatio', () => {
       it('returns the correct postSqrtPrice when it is just below the next initialized tick')
       it('returns the correct postSqrtPrice when it corresponds exactly with the next initialized tick')
       it('returns the correct postSqrtPrice when it is just above the next initialized tick')
+      it('returns the correct postSqrtPrice when fee cancels out benefit of swapping')
     })
 
     describe('when initial deposit has excess of token1', () => {
@@ -72,6 +127,63 @@ describe('SwapToRatio', () => {
       it('returns the correct postSqrtPrice when it is just below the next initialized tick')
       it('returns the correct postSqrtPrice when it corresponds exactly with the next initialized tick')
       it('returns the correct postSqrtPrice when it is just above the next initialized tick')
+      it('returns the correct postSqrtPrice when fee cancels out benefit of swapping')
+    })
+  })
+
+  describe('#tradeToNextTick', () => {
+    // position params
+    let amount0Initial: BigNumberish
+    let amount1Initial: BigNumberish
+    let sqrtPriceLower: BigNumberish
+    let sqrtPriceUpper: BigNumberish
+
+    // pool params
+    let liquidity: BigNumberish
+    let sqrtPrice: BigNumberish
+    let fee: BigNumberish
+
+    // other params
+    let sqrtPriceTarget: BigNumberish
+    let zeroForOne: boolean
+
+    before('load fixture', async () => {
+      swapToRatio = await loadFixture(swapToRatioPartialFixture)
+    })
+
+    describe('when initial deposit has excess of token0', () => {
+      it('returns true if sqrtPriceTarget falls right below next tick')
+      it('returns true if sqrtPriceTarget falls exactly at next tick')
+      it('returns false if sqrtPriceTarget falls right above next tick')
+    })
+
+    describe.only('when initial deposit has excess of token1', () => {
+      it('returns false if sqrtPriceTarget falls right below next tick')
+      it('returns false if sqrtPriceTarget falls exactly at next tick', async () => {
+        amount0Initial = 2_000
+        amount1Initial = 8_000
+        sqrtPriceLower = 1_000
+        sqrtPriceUpper = 2_000
+        sqrtPrice = 1_500
+        liquidity = 3_000
+        fee = 10000
+        sqrtPriceTarget = 1_505
+        zeroForOne = false
+
+        await tradeToNextTick(swapToRatio, {
+          amount0Initial,
+          amount1Initial,
+          sqrtPriceLower,
+          sqrtPriceUpper,
+          sqrtPrice,
+          liquidity,
+          fee,
+          sqrtPriceTarget,
+          zeroForOne,
+        })
+      })
+
+      it('returns true if sqrtPriceTarget falls right above next tick')
     })
   })
 })

--- a/test/SwapToRatioTest.spec.ts
+++ b/test/SwapToRatioTest.spec.ts
@@ -6,44 +6,57 @@ import { expect } from 'chai'
 import { expandTo18Decimals } from './shared/expandTo18Decimals'
 import completeFixture from './shared/completeFixture'
 
-const toFixedPoint96 = (n: BigNumberish): BigNumberish => {
-  return BigNumber.from(n).mul(BigNumber.from(2).pow(96))
+const toFixedPoint96 = (n: number): BigNumber => {
+  return BigNumber.from((Math.sqrt(n) * 1e18).toString())
+    .mul(BigNumber.from(2).pow(96))
+    .div((1e18).toString())
 }
 
-type tradeToNextTickArgs = {
-  sqrtPrice: BigNumberish
+type swapToNextTickArgs = {
+  // pool params
+  price: number
   liquidity: BigNumberish
   fee: BigNumberish
-  sqrtPriceLower: BigNumberish
-  sqrtPriceUpper: BigNumberish
+
+  // position params
+  priceLower: number
+  priceUpper: number
   amount0Initial: BigNumberish
   amount1Initial: BigNumberish
-  sqrtPriceTarget: BigNumberish
+
+  // other params
+  priceTarget: number
   zeroForOne: boolean
 }
 
-async function tradeToNextTick(swapToRatio: SwapToRatioTest, args: tradeToNextTickArgs): Promise<boolean> {
+async function swapToNextTick(
+  swapToRatio: SwapToRatioTest,
+  args: swapToNextTickArgs
+): Promise<{ doSwap: boolean; amount0Updated: BigNumber; amount1Updated: BigNumber }> {
   const {
-    sqrtPrice,
+    price,
     liquidity,
     fee,
-    sqrtPriceLower,
-    sqrtPriceUpper,
+    priceLower,
+    priceUpper,
     amount0Initial,
     amount1Initial,
-    sqrtPriceTarget,
+    priceTarget,
     zeroForOne,
   } = args
-  const sqrtRatioX96 = toFixedPoint96(sqrtPrice)
-  const sqrtRatioX96Lower = toFixedPoint96(sqrtPriceLower)
-  const sqrtRatioX96Upper = toFixedPoint96(sqrtPriceUpper)
-  const sqrtRatioX96Target = toFixedPoint96(sqrtPriceTarget)
-  return swapToRatio.tradeToNextTick(
+  const sqrtRatioX96 = toFixedPoint96(price)
+  const sqrtRatioX96Lower = toFixedPoint96(priceLower)
+  const sqrtRatioX96Upper = toFixedPoint96(priceUpper)
+  const sqrtRatioX96Target = toFixedPoint96(priceTarget)
+
+  const { 0: doSwap, 1: amount0Updated, 2: amount1Updated } = await swapToRatio.swapToNextTick(
     { sqrtRatioX96, liquidity, fee },
     { sqrtRatioX96Lower, sqrtRatioX96Upper, amount0Initial, amount1Initial },
     sqrtRatioX96Target,
     zeroForOne
   )
+
+  return { doSwap, amount0Updated, amount1Updated }
 }
 
 describe.only('SwapToRatio', () => {
@@ -131,20 +144,20 @@ describe.only('SwapToRatio', () => {
     })
   })
 
-  describe('#tradeToNextTick', () => {
+  describe.only('#swapToNextTick', () => {
     // position params
     let amount0Initial: BigNumberish
     let amount1Initial: BigNumberish
-    let sqrtPriceLower: BigNumberish
-    let sqrtPriceUpper: BigNumberish
+    let priceLower: number
+    let priceUpper: number
 
     // pool params
     let liquidity: BigNumberish
-    let sqrtPrice: BigNumberish
+    let price: number
     let fee: BigNumberish
 
     // other params
-    let sqrtPriceTarget: BigNumberish
+    let priceTarget: number
     let zeroForOne: boolean
 
     before('load fixture', async () => {
@@ -152,38 +165,161 @@ describe.only('SwapToRatio', () => {
     })
 
     describe('when initial deposit has excess of token0', () => {
-      it('returns true if sqrtPriceTarget falls right below next tick')
-      it('returns true if sqrtPriceTarget falls exactly at next tick')
-      it('returns false if sqrtPriceTarget falls right above next tick')
-    })
-
-    describe.only('when initial deposit has excess of token1', () => {
-      it('returns false if sqrtPriceTarget falls right below next tick')
-      it('returns false if sqrtPriceTarget falls exactly at next tick', async () => {
-        amount0Initial = 2_000
-        amount1Initial = 8_000
-        sqrtPriceLower = 1_000
-        sqrtPriceUpper = 2_000
-        sqrtPrice = 1_500
+      before(() => {
+        amount0Initial = 5_000
+        amount1Initial = 1_000
+        priceLower = 0.5
+        priceUpper = 1.5
+        price = 1
         liquidity = 3_000
         fee = 10000
-        sqrtPriceTarget = 1_505
-        zeroForOne = false
-
-        await tradeToNextTick(swapToRatio, {
-          amount0Initial,
-          amount1Initial,
-          sqrtPriceLower,
-          sqrtPriceUpper,
-          sqrtPrice,
-          liquidity,
-          fee,
-          sqrtPriceTarget,
-          zeroForOne,
-        })
+        zeroForOne = true
       })
 
-      it('returns true if sqrtPriceTarget falls right above next tick')
+      it('returns true if priceTarget falls above ideal price', async () => {
+        priceTarget = 0.9
+
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+          amount0Initial,
+          amount1Initial,
+          priceLower,
+          priceUpper,
+          price,
+          liquidity,
+          fee,
+          priceTarget,
+          zeroForOne,
+        })
+
+        expect(amount0Updated).to.eq(4837)
+        expect(amount1Updated).to.eq(1154)
+        expect(doSwap).to.eq(true)
+      })
+
+      it('returns true if priceTarget is exactly at ideal price', async () => {
+        priceTarget = 0.83597
+
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+          amount0Initial,
+          amount1Initial,
+          priceLower,
+          priceUpper,
+          price,
+          liquidity,
+          fee,
+          priceTarget,
+          zeroForOne,
+        })
+
+        expect(amount0Updated).to.eq(4717)
+        expect(amount1Updated).to.eq(1258)
+        expect(doSwap).to.eq(true)
+      })
+
+      it('returns false if priceTarget falls well below ideal price', async () => {
+        priceTarget = 0.6
+
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+          amount0Initial,
+          amount1Initial,
+          priceLower,
+          priceUpper,
+          price,
+          liquidity,
+          fee,
+          priceTarget,
+          zeroForOne,
+        })
+
+        expect(amount0Updated).to.eq(4120)
+        expect(amount1Updated).to.eq(1677)
+        expect(doSwap).to.eq(false)
+      })
+
+      // TODO: According the quadratic formula, the ideal price is 0.84, so I would expect targetPrice 0.7 to return false
+      it.skip('returns false if priceTarget falls right below ideal price', async () => {
+        priceTarget = 0.7
+
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+          amount0Initial,
+          amount1Initial,
+          priceLower,
+          priceUpper,
+          price,
+          liquidity,
+          fee,
+          priceTarget,
+          zeroForOne,
+        })
+
+        expect(amount0Updated).to.eq(4410)
+        expect(amount1Updated).to.eq(1491)
+        expect(doSwap).to.eq(false)
+      })
+
+      describe('when the next initialized tick is below the lower bound of the position range', () => {
+        it('returns the correct values instead of erroring with invalid opcode')
+      })
+    })
+
+    describe('when initial deposit has excess of token1', () => {
+      it('returns false if priceTarget falls right below next tick')
+
+      it('returns true if priceTarget falls exactly at next tick', async () => {
+        amount0Initial = 1_000
+        amount1Initial = 5_000
+        priceLower = 0.5
+        priceUpper = 1.5
+        price = 1
+        liquidity = 3_000
+        fee = 10000
+        priceTarget = 1.187901
+        zeroForOne = false
+
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+          amount0Initial,
+          amount1Initial,
+          priceLower,
+          priceUpper,
+          price,
+          liquidity,
+          fee,
+          priceTarget,
+          zeroForOne,
+        })
+
+        expect(doSwap).to.eq(true)
+        expect(amount0Updated).to.eq(1248)
+        expect(amount1Updated).to.eq(4729)
+      })
+
+      it('returns false if priceTarget falls above the next tick', async () => {
+        amount0Initial = 1_000
+        amount1Initial = 5_000
+        priceLower = 0.5
+        priceUpper = 1.5
+        price = 1
+        liquidity = 3_000
+        fee = 10000
+        priceTarget = 1.1
+        zeroForOne = false
+
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+          amount0Initial,
+          amount1Initial,
+          priceLower,
+          priceUpper,
+          price,
+          liquidity,
+          fee,
+          priceTarget,
+          zeroForOne,
+        })
+
+        expect(doSwap).to.eq(true)
+        expect(amount0Updated).to.eq(1140)
+        expect(amount1Updated).to.eq(4853)
+      })
     })
   })
 })

--- a/test/SwapToRatioTest.spec.ts
+++ b/test/SwapToRatioTest.spec.ts
@@ -488,7 +488,7 @@ describe.only('SwapToRatio', () => {
             deadline: 1,
             amountIn: amountToSwap.abs(),
             amountOutMinimum: 0,
-            sqrtPriceLimitX96: expandTo18Decimals(100_000)
+            sqrtPriceLimitX96: expandTo18Decimals(100_000),
           })
 
           expect(amountOut.add(amount1Initial)).to.equal(amount1Updated)
@@ -520,7 +520,7 @@ describe.only('SwapToRatio', () => {
             deadline: 1,
             amountIn: amountToSwap.abs(),
             amountOutMinimum: 0,
-            sqrtPriceLimitX96: expandTo18Decimals(100_000)
+            sqrtPriceLimitX96: expandTo18Decimals(100_000),
           })
 
           expect((await pool.slot0()).sqrtPriceX96).to.eq(sqrtRatioX96)
@@ -529,12 +529,14 @@ describe.only('SwapToRatio', () => {
         it('gas', async () => {
           amount0Initial = expandTo18Decimals(30_000)
           amount1Initial = expandTo18Decimals(1_000)
-          await snapshotGasCost(swapToRatio.swapToNextInitializedTickGas(
-            { sqrtRatioX96, liquidity, fee },
-            { sqrtRatioX96Lower, sqrtRatioX96Upper, amount0Initial, amount1Initial },
-            sqrtRatioX96Target,
-            zeroForOne
-          ))
+          await snapshotGasCost(
+            swapToRatio.swapToNextInitializedTickGas(
+              { sqrtRatioX96, liquidity, fee },
+              { sqrtRatioX96Lower, sqrtRatioX96Upper, amount0Initial, amount1Initial },
+              sqrtRatioX96Target,
+              zeroForOne
+            )
+          )
         })
       })
     })

--- a/test/SwapToRatioTest.spec.ts
+++ b/test/SwapToRatioTest.spec.ts
@@ -10,6 +10,7 @@ import { getMaxTick, getMinTick } from './shared/ticks'
 import completeFixture from './shared/completeFixture'
 import { computePoolAddress } from './shared/computePoolAddress'
 import { sortedTokens } from './shared/tokenSort'
+import snapshotGasCost from './shared/snapshotGasCost'
 
 import { abi as IUniswapV3PoolABI } from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json'
 
@@ -523,6 +524,17 @@ describe.only('SwapToRatio', () => {
           })
 
           expect((await pool.slot0()).sqrtPriceX96).to.eq(sqrtRatioX96)
+        })
+
+        it('gas', async () => {
+          amount0Initial = expandTo18Decimals(30_000)
+          amount1Initial = expandTo18Decimals(1_000)
+          await snapshotGasCost(swapToRatio.swapToNextInitializedTickGas(
+            { sqrtRatioX96, liquidity, fee },
+            { sqrtRatioX96Lower, sqrtRatioX96Upper, amount0Initial, amount1Initial },
+            sqrtRatioX96Target,
+            zeroForOne
+          ))
         })
       })
     })

--- a/test/SwapToRatioTest.spec.ts
+++ b/test/SwapToRatioTest.spec.ts
@@ -1,4 +1,4 @@
-import { BigNumber, BigNumberish, constants } from 'ethers'
+import { BigNumber, BigNumberish, Contract, constants } from 'ethers'
 import { waffle, ethers } from 'hardhat'
 import { Fixture } from 'ethereum-waffle'
 import { SwapToRatioTest, TestERC20, MockTimeNonfungiblePositionManager, SwapRouter } from '../typechain'
@@ -8,62 +8,10 @@ import { encodePriceSqrt } from './shared/encodePriceSqrt'
 import { FeeAmount, MaxUint128, TICK_SPACINGS } from './shared/constants'
 import { getMaxTick, getMinTick } from './shared/ticks'
 import completeFixture from './shared/completeFixture'
+import { computePoolAddress } from './shared/computePoolAddress'
 import { sortedTokens } from './shared/tokenSort'
 
-// TODO: oops,  maybe just use encodePriceSqrt. But being able to use decimals here
-// instead of fractions is convenient to more easily test against Dan's desmos sheets
-const toSqrtFixedPoint96 = (n: number): BigNumber => {
-  return BigNumber.from((Math.sqrt(n) * 1e18).toString())
-    .mul(BigNumber.from(2).pow(96))
-    .div((1e18).toString())
-}
-
-type swapToNextInitializedTickArgs = {
-  // pool params
-  price: number
-  liquidity: BigNumberish
-  fee: BigNumberish
-
-  // position params
-  priceLower: number
-  priceUpper: number
-  amount0Initial: BigNumberish
-  amount1Initial: BigNumberish
-
-  // other params
-  priceTarget: number
-  zeroForOne: boolean
-}
-
-async function swapToNextInitializedTick(
-  swapToRatio: SwapToRatioTest,
-  args: swapToNextInitializedTickArgs
-): Promise<{ doSwap: boolean; amount0Updated: BigNumber; amount1Updated: BigNumber }> {
-  const {
-    price,
-    liquidity,
-    fee,
-    priceLower,
-    priceUpper,
-    amount0Initial,
-    amount1Initial,
-    priceTarget,
-    zeroForOne,
-  } = args
-  const sqrtRatioX96 = toSqrtFixedPoint96(price)
-  const sqrtRatioX96Lower = toSqrtFixedPoint96(priceLower)
-  const sqrtRatioX96Upper = toSqrtFixedPoint96(priceUpper)
-  const sqrtRatioX96Target = toSqrtFixedPoint96(priceTarget)
-
-  const { 0: doSwap, 1: amount0Updated, 2: amount1Updated } = await swapToRatio.swapToNextInitializedTick(
-    { sqrtRatioX96, liquidity, fee },
-    { sqrtRatioX96Lower, sqrtRatioX96Upper, amount0Initial, amount1Initial },
-    sqrtRatioX96Target,
-    zeroForOne
-  )
-
-  return { doSwap, amount0Updated, amount1Updated }
-}
+import { abi as IUniswapV3PoolABI } from '@uniswap/v3-core/artifacts/contracts/interfaces/IUniswapV3Pool.sol/IUniswapV3Pool.json'
 
 describe.only('SwapToRatio', () => {
   const [...wallets] = waffle.provider.getWallets()
@@ -102,8 +50,8 @@ describe.only('SwapToRatio', () => {
   let swapToRatio: SwapToRatioTest
   let nft: MockTimeNonfungiblePositionManager
   let router: SwapRouter
-  let token0: {address: string}
-  let token1: {address: string}
+  let token0: { address: string }
+  let token1: { address: string }
 
   const amountDesired = 100
 
@@ -113,12 +61,12 @@ describe.only('SwapToRatio', () => {
   })
 
   describe('#getPostSwapPrice ', () => {
-    beforeEach('setup pool', async () => {
+    beforeEach('load fixture', async () => {
       ;({ tokens, swapToRatio, nft, router } = await loadFixture(swapToRatioCompleteFixture))
     })
 
     beforeEach('setup pool', async () => {
-      [token0, token1] = sortedTokens(tokens[0], tokens[1])
+      ;[token0, token1] = sortedTokens(tokens[0], tokens[1])
 
       await nft.createAndInitializePoolIfNecessary(
         tokens[0].address,
@@ -157,17 +105,13 @@ describe.only('SwapToRatio', () => {
     })
 
     describe('when initial deposit has excess of token0', () => {
-      it('returns the correct postSqrtPrice when it is just below the next initialized tick', async () => {
-
-      })
+      it('returns the correct postSqrtPrice when it is just below the next initialized tick', async () => {})
       it('returns the correct postSqrtPrice when it corresponds exactly with the next initialized tick')
       it('returns the correct postSqrtPrice when it is just above the next initialized tick')
       it('returns the correct postSqrtPrice when fee cancels out benefit of swapping')
 
       describe('and swap does not push price beyond the next initialized tick', () => {
-        it('does the thing', async () => {
-
-        })
+        it('does the thing', async () => {})
         // it returns the correct postSqrtPrice for various values
       })
 
@@ -216,205 +160,331 @@ describe.only('SwapToRatio', () => {
     let priceTarget: number
     let zeroForOne: boolean
 
-    before('load fixture', async () => {
-      swapToRatio = await loadFixture(swapToRatioPartialFixture)
-    })
-
-    describe('when initial deposit has excess of token0', () => {
-      // desmos sheet for the following numbers: https://www.desmos.com/calculator/b4lcwrzc4f
-      before(() => {
-        amount0Initial = 5_000
-        amount1Initial = 1_000
-        priceLower = 0.5
-        priceUpper = 2
-        price = 1
-        liquidity = 3_000
-        fee = 10000
-        zeroForOne = true
+    describe('when tested with simple numbers', () => {
+      before('load fixture', async () => {
+        swapToRatio = await loadFixture(swapToRatioPartialFixture)
       })
 
-      it('returns true if priceTarget falls right above the ideal price', async () => {
-        priceTarget = 0.84
-
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
-          amount0Initial,
-          amount1Initial,
-          priceLower,
-          priceUpper,
-          price,
-          liquidity,
-          fee,
-          priceTarget,
-          zeroForOne,
+      describe('when initial deposit has excess of token0', () => {
+        // desmos sheet for the following numbers: https://www.desmos.com/calculator/b4lcwrzc4f
+        before(() => {
+          amount0Initial = 5_000
+          amount1Initial = 1_000
+          priceLower = 0.5
+          priceUpper = 2
+          price = 1
+          liquidity = 3_000
+          fee = 10000
+          zeroForOne = true
         })
 
-        expect(amount0Updated).to.eq(4725)
-        expect(amount1Updated).to.eq(1251)
-        expect(doSwap).to.eq(true)
-      })
-
-      it('returns true if priceTarget is exactly at ideal price', async () => {
-        priceTarget = 0.83597
-
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
-          amount0Initial,
-          amount1Initial,
-          priceLower,
-          priceUpper,
-          price,
-          liquidity,
-          fee,
-          priceTarget,
-          zeroForOne,
-        })
-
-        expect(amount0Updated).to.eq(4717)
-        expect(amount1Updated).to.eq(1258)
-        expect(doSwap).to.eq(true)
-      })
-
-      it('returns false if priceTarget falls right below ideal price', async () => {
-        // TODO: According the quadratic formula, the ideal price is 0.84, 0.73 is the highest next price that will return false. this ok?
-        priceTarget = 0.73
-
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
-          amount0Initial,
-          amount1Initial,
-          priceLower,
-          priceUpper,
-          price,
-          liquidity,
-          fee,
-          priceTarget,
-          zeroForOne,
-        })
-
-        expect(doSwap).to.eq(false)
-        expect(amount0Updated).to.eq(4484)
-        expect(amount1Updated).to.eq(1437)
-      })
-
-      describe('when the next initialized tick is below the lower bound of the position range', () => {
-        it('returns null values', async () => {
-          priceTarget = 0.1
+        it('returns true if priceTarget falls right above the ideal price', async () => {
+          priceTarget = 0.84
 
           const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
             amount0Initial,
             amount1Initial,
-            priceLower,
-            priceUpper,
-            price,
+            sqrtRatioX96Lower: toSqrtFixedPoint96(priceLower),
+            sqrtRatioX96Upper: toSqrtFixedPoint96(priceUpper),
+            sqrtRatioX96: toSqrtFixedPoint96(price),
             liquidity,
             fee,
-            priceTarget,
+            sqrtRatioX96Target: toSqrtFixedPoint96(priceTarget),
             zeroForOne,
           })
 
-          expect(doSwap).to.eq(false)
-          expect(amount0Updated).to.eq(0)
-          expect(amount1Updated).to.eq(0)
-        })
-      })
-    })
-
-    describe('when initial deposit has excess of token1', () => {
-      // desmos math sheet for following numbers: https://www.desmos.com/calculator/5rtr2rycan
-      before(() => {
-        amount0Initial = 1_000
-        amount1Initial = 5_000
-        priceLower = 0.5
-        priceUpper = 2
-        price = 1
-        liquidity = 3_000
-        fee = 10000
-        zeroForOne = false
-      })
-
-      it('returns true if priceTarget falls right below ideal price', async () => {
-        // idealPrice = 1.3678
-        priceTarget = 1.366
-
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
-          amount0Initial,
-          amount1Initial,
-          priceLower,
-          priceUpper,
-          price,
-          liquidity,
-          fee,
-          priceTarget,
-          zeroForOne,
+          expect(amount0Updated).to.eq(4725)
+          expect(amount1Updated).to.eq(1251)
+          expect(doSwap).to.eq(true)
         })
 
-        expect(doSwap).to.eq(true)
-        // TODO: rounding, results in desmos are 1433 and 4488  respectively, this ok?
-        expect(amount0Updated).to.eq(1434)
-        expect(amount1Updated).to.eq(4489)
-      })
+        it('returns true if priceTarget is exactly at ideal price', async () => {
+          priceTarget = 0.83597
 
-      it('returns true if priceTarget falls exactly at the ideal price', async () => {
-        // TODO: ideal price is 1.36786..., but 1.3676 is the highest I can get to return true. this ok?
-        priceTarget = 1.3676
-
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
-          amount0Initial,
-          amount1Initial,
-          priceLower,
-          priceUpper,
-          price,
-          liquidity,
-          fee,
-          priceTarget,
-          zeroForOne,
-        })
-
-        expect(doSwap).to.eq(true)
-        expect(amount0Updated).to.eq(1435)
-        expect(amount1Updated).to.eq(4487)
-      })
-
-      it('returns false if priceTarget falls above the ideal price', async () => {
-        // ideal price = 1.3678
-        priceTarget = 1.368
-
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
-          amount0Initial,
-          amount1Initial,
-          priceLower,
-          priceUpper,
-          price,
-          liquidity,
-          fee,
-          priceTarget,
-          zeroForOne,
-        })
-
-        expect(doSwap).to.eq(false)
-        expect(amount0Updated).to.eq(1436)
-        expect(amount1Updated).to.eq(4487)
-      })
-
-      describe('when the next initialized tick is above the the upper bound of the position range', () => {
-        it('returns null values', async () => {
-          priceTarget = 2.5
+          const sqrtRatioX96 = toSqrtFixedPoint96(price)
+          const sqrtRatioX96Lower = toSqrtFixedPoint96(priceLower)
+          const sqrtRatioX96Upper = toSqrtFixedPoint96(priceUpper)
+          const sqrtRatioX96Target = toSqrtFixedPoint96(priceTarget)
 
           const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
             amount0Initial,
             amount1Initial,
-            priceLower,
-            priceUpper,
-            price,
+            sqrtRatioX96Lower: toSqrtFixedPoint96(priceLower),
+            sqrtRatioX96Upper: toSqrtFixedPoint96(priceUpper),
+            sqrtRatioX96: toSqrtFixedPoint96(price),
             liquidity,
             fee,
-            priceTarget,
+            sqrtRatioX96Target: toSqrtFixedPoint96(priceTarget),
+            zeroForOne,
+          })
+
+          expect(amount0Updated).to.eq(4717)
+          expect(amount1Updated).to.eq(1258)
+          expect(doSwap).to.eq(true)
+        })
+
+        it('returns false if priceTarget falls right below ideal price', async () => {
+          // TODO: According the quadratic formula, the ideal price is 0.84, 0.73 is the highest next price that will return false. this ok?
+          priceTarget = 0.73
+
+          const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
+            amount0Initial,
+            amount1Initial,
+            sqrtRatioX96Lower: toSqrtFixedPoint96(priceLower),
+            sqrtRatioX96Upper: toSqrtFixedPoint96(priceUpper),
+            sqrtRatioX96: toSqrtFixedPoint96(price),
+            liquidity,
+            fee,
+            sqrtRatioX96Target: toSqrtFixedPoint96(priceTarget),
             zeroForOne,
           })
 
           expect(doSwap).to.eq(false)
-          expect(amount0Updated).to.eq(0)
-          expect(amount1Updated).to.eq(0)
+          expect(amount0Updated).to.eq(4484)
+          expect(amount1Updated).to.eq(1437)
+        })
+
+        describe('when the next initialized tick is below the lower bound of the position range', () => {
+          it('returns null values', async () => {
+            priceTarget = 0.1
+
+            const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
+              amount0Initial,
+              amount1Initial,
+              sqrtRatioX96Lower: toSqrtFixedPoint96(priceLower),
+              sqrtRatioX96Upper: toSqrtFixedPoint96(priceUpper),
+              sqrtRatioX96: toSqrtFixedPoint96(price),
+              liquidity,
+              fee,
+              sqrtRatioX96Target: toSqrtFixedPoint96(priceTarget),
+              zeroForOne,
+            })
+
+            expect(doSwap).to.eq(false)
+            expect(amount0Updated).to.eq(0)
+            expect(amount1Updated).to.eq(0)
+          })
+        })
+      })
+
+      describe('when initial deposit has excess of token1', () => {
+        // desmos math sheet for following numbers: https://www.desmos.com/calculator/5rtr2rycan
+        before(() => {
+          amount0Initial = 1_000
+          amount1Initial = 5_000
+          priceLower = 0.5
+          priceUpper = 2
+          price = 1
+          liquidity = 3_000
+          fee = 10000
+          zeroForOne = false
+        })
+
+        it('returns true if priceTarget falls right below ideal price', async () => {
+          // idealPrice = 1.3678
+          priceTarget = 1.366
+
+          const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
+            amount0Initial,
+            amount1Initial,
+            sqrtRatioX96Lower: toSqrtFixedPoint96(priceLower),
+            sqrtRatioX96Upper: toSqrtFixedPoint96(priceUpper),
+            sqrtRatioX96: toSqrtFixedPoint96(price),
+            liquidity,
+            fee,
+            sqrtRatioX96Target: toSqrtFixedPoint96(priceTarget),
+            zeroForOne,
+          })
+
+          expect(doSwap).to.eq(true)
+          // TODO: rounding, results in desmos are 1433 and 4488  respectively, this ok?
+          expect(amount0Updated).to.eq(1434)
+          expect(amount1Updated).to.eq(4489)
+        })
+
+        it('returns true if priceTarget falls exactly at the ideal price', async () => {
+          // TODO: ideal price is 1.36786..., but 1.3676 is the highest I can get to return true. this ok?
+          priceTarget = 1.3676
+
+          const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
+            amount0Initial,
+            amount1Initial,
+            sqrtRatioX96Lower: toSqrtFixedPoint96(priceLower),
+            sqrtRatioX96Upper: toSqrtFixedPoint96(priceUpper),
+            sqrtRatioX96: toSqrtFixedPoint96(price),
+            liquidity,
+            fee,
+            sqrtRatioX96Target: toSqrtFixedPoint96(priceTarget),
+            zeroForOne,
+          })
+
+          expect(doSwap).to.eq(true)
+          expect(amount0Updated).to.eq(1435)
+          expect(amount1Updated).to.eq(4487)
+        })
+
+        it('returns false if priceTarget falls above the ideal price', async () => {
+          // ideal price = 1.3678
+          priceTarget = 1.368
+
+          const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
+            amount0Initial,
+            amount1Initial,
+            sqrtRatioX96Lower: toSqrtFixedPoint96(priceLower),
+            sqrtRatioX96Upper: toSqrtFixedPoint96(priceUpper),
+            sqrtRatioX96: toSqrtFixedPoint96(price),
+            liquidity,
+            fee,
+            sqrtRatioX96Target: toSqrtFixedPoint96(priceTarget),
+            zeroForOne,
+          })
+
+          expect(doSwap).to.eq(false)
+          expect(amount0Updated).to.eq(1436)
+          expect(amount1Updated).to.eq(4487)
+        })
+
+        describe('when the next initialized tick is above the the upper bound of the position range', () => {
+          it('returns null values', async () => {
+            priceTarget = 2.5
+
+            const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
+              amount0Initial,
+              amount1Initial,
+              sqrtRatioX96Lower: toSqrtFixedPoint96(priceLower),
+              sqrtRatioX96Upper: toSqrtFixedPoint96(priceUpper),
+              sqrtRatioX96: toSqrtFixedPoint96(price),
+              liquidity,
+              fee,
+              sqrtRatioX96Target: toSqrtFixedPoint96(priceTarget),
+              zeroForOne,
+            })
+
+            expect(doSwap).to.eq(false)
+            expect(amount0Updated).to.eq(0)
+            expect(amount1Updated).to.eq(0)
+          })
+        })
+      })
+    })
+
+    describe('when tested against actual swaps', () => {
+      let pool: Contract
+      beforeEach('load fixture', async () => {
+        ;({ tokens, swapToRatio, nft, router } = await loadFixture(swapToRatioCompleteFixture))
+        const poolAddress = computePoolAddress(
+          await nft.factory(),
+          [tokens[0].address, tokens[1].address],
+          FeeAmount.MEDIUM
+        )
+        pool = new Contract(poolAddress, IUniswapV3PoolABI, wallets[0])
+      })
+
+      beforeEach('setup pool', async () => {
+        ;[token0, token1] = sortedTokens(tokens[0], tokens[1])
+
+        const tickLower = getMinTick(TICK_SPACINGS[FeeAmount.MEDIUM])
+        const tickUpper = getMaxTick(TICK_SPACINGS[FeeAmount.MEDIUM])
+        // priceLower = await swapToRatio.getSqrtRatioAtTick
+
+
+        await nft.createAndInitializePoolIfNecessary(
+          tokens[0].address,
+          tokens[1].address,
+          FeeAmount.MEDIUM,
+          encodePriceSqrt(1, 1)
+        )
+
+        await nft.mint({
+          token0: token0.address,
+          token1: token1.address,
+          fee: FeeAmount.MEDIUM,
+          tickLower: getMinTick(TICK_SPACINGS[FeeAmount.MEDIUM]),
+          tickUpper: getMaxTick(TICK_SPACINGS[FeeAmount.MEDIUM]),
+          amount0Desired: expandTo18Decimals(10_000),
+          amount1Desired: expandTo18Decimals(10_000),
+          amount0Min: 0,
+          amount1Min: 0,
+          recipient: wallets[0].address,
+          deadline: 1,
+        })
+
+        await nft.mint({
+          token0: token0.address,
+          token1: token1.address,
+          fee: FeeAmount.MEDIUM,
+          tickLower: TICK_SPACINGS[FeeAmount.MEDIUM] * -1,
+          tickUpper: TICK_SPACINGS[FeeAmount.MEDIUM] * 1,
+          amount0Desired: expandTo18Decimals(1_000),
+          amount1Desired: expandTo18Decimals(1_000),
+          amount0Min: 0,
+          amount1Min: 0,
+          recipient: wallets[0].address,
+          deadline: 1,
+        })
+      })
+
+      describe('initial deposit has excess of token0', async () => {
+        it('returns token amounts which reflect a real post swap amounts', async () => {
+          const slot0 = await pool.slot0()
+          liquidity = await pool.liquidity()
+          fee = FeeAmount.MEDIUM
+          // console.log(slot0)
+
+
         })
       })
     })
   })
 })
+
+// TODO: oops,  maybe just use encodePriceSqrt. But being able to use decimals here
+// instead of fractions is convenient to more easily test against Dan's desmos sheets
+const toSqrtFixedPoint96 = (n: number): BigNumber => {
+  return BigNumber.from((Math.sqrt(n) * 1e18).toString())
+    .mul(BigNumber.from(2).pow(96))
+    .div((1e18).toString())
+}
+
+type swapToNextInitializedTickArgs = {
+  // pool params
+  sqrtRatioX96: BigNumberish
+  liquidity: BigNumberish
+  fee: BigNumberish
+
+  // position params
+  sqrtRatioX96Lower: BigNumberish
+  sqrtRatioX96Upper: BigNumberish
+  amount0Initial: BigNumberish
+  amount1Initial: BigNumberish
+
+  // other params
+  sqrtRatioX96Target: BigNumberish
+  zeroForOne: boolean
+}
+
+async function swapToNextInitializedTick(
+  swapToRatio: SwapToRatioTest,
+  args: swapToNextInitializedTickArgs
+): Promise<{ doSwap: boolean; amount0Updated: BigNumber; amount1Updated: BigNumber }> {
+  const {
+    sqrtRatioX96,
+    liquidity,
+    fee,
+    sqrtRatioX96Lower,
+    sqrtRatioX96Upper,
+    amount0Initial,
+    amount1Initial,
+    sqrtRatioX96Target,
+    zeroForOne,
+  } = args
+
+  const { 0: doSwap, 1: amount0Updated, 2: amount1Updated } = await swapToRatio.swapToNextInitializedTick(
+    { sqrtRatioX96, liquidity, fee },
+    { sqrtRatioX96Lower, sqrtRatioX96Upper, amount0Initial, amount1Initial },
+    sqrtRatioX96Target,
+    zeroForOne
+  )
+
+  return { doSwap, amount0Updated, amount1Updated }
+}

--- a/test/SwapToRatioTest.spec.ts
+++ b/test/SwapToRatioTest.spec.ts
@@ -12,7 +12,7 @@ const toFixedPoint96 = (n: number): BigNumber => {
     .div((1e18).toString())
 }
 
-type swapToNextTickArgs = {
+type swapToNextInitializedTickArgs = {
   // pool params
   price: number
   liquidity: BigNumberish
@@ -29,9 +29,9 @@ type swapToNextTickArgs = {
   zeroForOne: boolean
 }
 
-async function swapToNextTick(
+async function swapToNextInitializedTick(
   swapToRatio: SwapToRatioTest,
-  args: swapToNextTickArgs
+  args: swapToNextInitializedTickArgs
 ): Promise<{ doSwap: boolean; amount0Updated: BigNumber; amount1Updated: BigNumber }> {
   const {
     price,
@@ -49,7 +49,7 @@ async function swapToNextTick(
   const sqrtRatioX96Upper = toFixedPoint96(priceUpper)
   const sqrtRatioX96Target = toFixedPoint96(priceTarget)
 
-  const { 0: doSwap, 1: amount0Updated, 2: amount1Updated } = await swapToRatio.swapToNextTick(
+  const { 0: doSwap, 1: amount0Updated, 2: amount1Updated } = await swapToRatio.swapToNextInitializedTick(
     { sqrtRatioX96, liquidity, fee },
     { sqrtRatioX96Lower, sqrtRatioX96Upper, amount0Initial, amount1Initial },
     sqrtRatioX96Target,
@@ -144,7 +144,7 @@ describe.only('SwapToRatio', () => {
     })
   })
 
-  describe.only('#swapToNextTick', () => {
+  describe.only('#swapToNextInitializedTick', () => {
     // position params
     let amount0Initial: BigNumberish
     let amount1Initial: BigNumberish
@@ -180,7 +180,7 @@ describe.only('SwapToRatio', () => {
       it('returns true if priceTarget falls right above the ideal price', async () => {
         priceTarget = 0.84
 
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
           amount0Initial,
           amount1Initial,
           priceLower,
@@ -200,7 +200,7 @@ describe.only('SwapToRatio', () => {
       it('returns true if priceTarget is exactly at ideal price', async () => {
         priceTarget = 0.83597
 
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
           amount0Initial,
           amount1Initial,
           priceLower,
@@ -221,7 +221,7 @@ describe.only('SwapToRatio', () => {
         // TODO: According the quadratic formula, the ideal price is 0.84, 0.73 is the highest next price that will return false. this ok?
         priceTarget = 0.73
 
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
           amount0Initial,
           amount1Initial,
           priceLower,
@@ -242,7 +242,7 @@ describe.only('SwapToRatio', () => {
         it('returns null values', async () => {
           priceTarget = 0.1
 
-          const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+          const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
             amount0Initial,
             amount1Initial,
             priceLower,
@@ -278,7 +278,7 @@ describe.only('SwapToRatio', () => {
         // idealPrice = 1.3678
         priceTarget = 1.366
 
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
           amount0Initial,
           amount1Initial,
           priceLower,
@@ -300,7 +300,7 @@ describe.only('SwapToRatio', () => {
         // TODO: ideal price is 1.36786..., but 1.3676 is the highest I can get to return true. this ok?
         priceTarget = 1.3676
 
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
           amount0Initial,
           amount1Initial,
           priceLower,
@@ -321,7 +321,7 @@ describe.only('SwapToRatio', () => {
         // ideal price = 1.3678
         priceTarget = 1.368
 
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
           amount0Initial,
           amount1Initial,
           priceLower,
@@ -342,7 +342,7 @@ describe.only('SwapToRatio', () => {
         it('returns null values', async () => {
           priceTarget = 2.5
 
-          const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+          const { doSwap, amount0Updated, amount1Updated } = await swapToNextInitializedTick(swapToRatio, {
             amount0Initial,
             amount1Initial,
             priceLower,

--- a/test/SwapToRatioTest.spec.ts
+++ b/test/SwapToRatioTest.spec.ts
@@ -165,19 +165,20 @@ describe.only('SwapToRatio', () => {
     })
 
     describe('when initial deposit has excess of token0', () => {
+      // desmos sheet for the following numbers: https://www.desmos.com/calculator/b4lcwrzc4f
       before(() => {
         amount0Initial = 5_000
         amount1Initial = 1_000
         priceLower = 0.5
-        priceUpper = 1.5
+        priceUpper = 2
         price = 1
         liquidity = 3_000
         fee = 10000
         zeroForOne = true
       })
 
-      it('returns true if priceTarget falls above ideal price', async () => {
-        priceTarget = 0.9
+      it('returns true if priceTarget falls right above the ideal price', async () => {
+        priceTarget = 0.84
 
         const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
           amount0Initial,
@@ -191,8 +192,8 @@ describe.only('SwapToRatio', () => {
           zeroForOne,
         })
 
-        expect(amount0Updated).to.eq(4837)
-        expect(amount1Updated).to.eq(1154)
+        expect(amount0Updated).to.eq(4725)
+        expect(amount1Updated).to.eq(1251)
         expect(doSwap).to.eq(true)
       })
 
@@ -216,8 +217,9 @@ describe.only('SwapToRatio', () => {
         expect(doSwap).to.eq(true)
       })
 
-      it('returns false if priceTarget falls well below ideal price', async () => {
-        priceTarget = 0.6
+      it('returns false if priceTarget falls right below ideal price', async () => {
+        // TODO: According the quadratic formula, the ideal price is 0.84, 0.73 is the highest next price that will return false. this ok?
+        priceTarget = 0.73
 
         const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
           amount0Initial,
@@ -231,78 +233,50 @@ describe.only('SwapToRatio', () => {
           zeroForOne,
         })
 
-        expect(amount0Updated).to.eq(4120)
-        expect(amount1Updated).to.eq(1677)
         expect(doSwap).to.eq(false)
-      })
-
-      // TODO: According the quadratic formula, the ideal price is 0.84, so I would expect targetPrice 0.7 to return false
-      it.skip('returns false if priceTarget falls right below ideal price', async () => {
-        priceTarget = 0.7
-
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
-          amount0Initial,
-          amount1Initial,
-          priceLower,
-          priceUpper,
-          price,
-          liquidity,
-          fee,
-          priceTarget,
-          zeroForOne,
-        })
-
-        expect(amount0Updated).to.eq(4410)
-        expect(amount1Updated).to.eq(1491)
-        expect(doSwap).to.eq(false)
+        expect(amount0Updated).to.eq(4484)
+        expect(amount1Updated).to.eq(1437)
       })
 
       describe('when the next initialized tick is below the lower bound of the position range', () => {
-        it('returns the correct values instead of erroring with invalid opcode')
+        it('returns null values', async () => {
+          priceTarget = 0.1
+
+          const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+            amount0Initial,
+            amount1Initial,
+            priceLower,
+            priceUpper,
+            price,
+            liquidity,
+            fee,
+            priceTarget,
+            zeroForOne,
+          })
+
+          expect(doSwap).to.eq(false)
+          expect(amount0Updated).to.eq(0)
+          expect(amount1Updated).to.eq(0)
+        })
       })
     })
 
     describe('when initial deposit has excess of token1', () => {
-      it('returns false if priceTarget falls right below next tick')
-
-      it('returns true if priceTarget falls exactly at next tick', async () => {
+      // desmos math sheet for following numbers: https://www.desmos.com/calculator/5rtr2rycan
+      before(() => {
         amount0Initial = 1_000
         amount1Initial = 5_000
         priceLower = 0.5
-        priceUpper = 1.5
+        priceUpper = 2
         price = 1
         liquidity = 3_000
         fee = 10000
-        priceTarget = 1.187901
         zeroForOne = false
-
-        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
-          amount0Initial,
-          amount1Initial,
-          priceLower,
-          priceUpper,
-          price,
-          liquidity,
-          fee,
-          priceTarget,
-          zeroForOne,
-        })
-
-        expect(doSwap).to.eq(true)
-        expect(amount0Updated).to.eq(1248)
-        expect(amount1Updated).to.eq(4729)
       })
 
-      it('returns false if priceTarget falls above the next tick', async () => {
-        amount0Initial = 1_000
-        amount1Initial = 5_000
-        priceLower = 0.5
-        priceUpper = 1.5
-        price = 1
-        liquidity = 3_000
-        fee = 10000
-        priceTarget = 1.1
-        zeroForOne = false
+      it('returns true if priceTarget falls right below ideal price', async () => {
+        // idealPrice = 1.3678
+        priceTarget = 1.366
 
         const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
           amount0Initial,
@@ -317,8 +291,73 @@ describe.only('SwapToRatio', () => {
         })
 
         expect(doSwap).to.eq(true)
-        expect(amount0Updated).to.eq(1140)
-        expect(amount1Updated).to.eq(4853)
+        // TODO: rounding, results in desmos are 1433 and 4488  respectively, this ok?
+        expect(amount0Updated).to.eq(1434)
+        expect(amount1Updated).to.eq(4489)
+      })
+
+      it('returns true if priceTarget falls exactly at the ideal price', async () => {
+        // TODO: ideal price is 1.36786..., but 1.3676 is the highest I can get to return true. this ok?
+        priceTarget = 1.3676
+
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+          amount0Initial,
+          amount1Initial,
+          priceLower,
+          priceUpper,
+          price,
+          liquidity,
+          fee,
+          priceTarget,
+          zeroForOne,
+        })
+
+        expect(doSwap).to.eq(true)
+        expect(amount0Updated).to.eq(1435)
+        expect(amount1Updated).to.eq(4487)
+      })
+
+      it('returns false if priceTarget falls above the ideal price', async () => {
+        // ideal price = 1.3678
+        priceTarget = 1.368
+
+        const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+          amount0Initial,
+          amount1Initial,
+          priceLower,
+          priceUpper,
+          price,
+          liquidity,
+          fee,
+          priceTarget,
+          zeroForOne,
+        })
+
+        expect(doSwap).to.eq(false)
+        expect(amount0Updated).to.eq(1436)
+        expect(amount1Updated).to.eq(4487)
+      })
+
+      describe('when the next initialized tick is above the the upper bound of the position range', () => {
+        it('returns null values', async () => {
+          priceTarget = 2.5
+
+          const { doSwap, amount0Updated, amount1Updated } = await swapToNextTick(swapToRatio, {
+            amount0Initial,
+            amount1Initial,
+            priceLower,
+            priceUpper,
+            price,
+            liquidity,
+            fee,
+            priceTarget,
+            zeroForOne,
+          })
+
+          expect(doSwap).to.eq(false)
+          expect(amount0Updated).to.eq(0)
+          expect(amount1Updated).to.eq(0)
+        })
       })
     })
   })

--- a/test/SwapToRatioTest.spec.ts
+++ b/test/SwapToRatioTest.spec.ts
@@ -6,7 +6,7 @@ import { expect } from 'chai'
 import { expandTo18Decimals } from './shared/expandTo18Decimals'
 import completeFixture from './shared/completeFixture'
 
-const toFixedPoint96 = (n: number): BigNumber => {
+const toSqrtFixedPoint96 = (n: number): BigNumber => {
   return BigNumber.from((Math.sqrt(n) * 1e18).toString())
     .mul(BigNumber.from(2).pow(96))
     .div((1e18).toString())
@@ -44,10 +44,10 @@ async function swapToNextInitializedTick(
     priceTarget,
     zeroForOne,
   } = args
-  const sqrtRatioX96 = toFixedPoint96(price)
-  const sqrtRatioX96Lower = toFixedPoint96(priceLower)
-  const sqrtRatioX96Upper = toFixedPoint96(priceUpper)
-  const sqrtRatioX96Target = toFixedPoint96(priceTarget)
+  const sqrtRatioX96 = toSqrtFixedPoint96(price)
+  const sqrtRatioX96Lower = toSqrtFixedPoint96(priceLower)
+  const sqrtRatioX96Upper = toSqrtFixedPoint96(priceUpper)
+  const sqrtRatioX96Target = toSqrtFixedPoint96(priceTarget)
 
   const { 0: doSwap, 1: amount0Updated, 2: amount1Updated } = await swapToRatio.swapToNextInitializedTick(
     { sqrtRatioX96, liquidity, fee },
@@ -105,8 +105,16 @@ describe.only('SwapToRatio', () => {
   })
 
   describe('#getPostSwapPrice ', () => {
-    describe('when initial deposit has excess of token0', () => {
+    beforeEach('setup pool', async () => {
+      ;({ tokens, swapToRatio, nft, router } = await loadFixture(swapToRatioCompleteFixture))
+
+    })
+
+    describe.only('when initial deposit has excess of token0', () => {
       describe('and swap does not push price beyond the next initialized tick', () => {
+        it('does the thing', async () => {
+
+        })
         // it returns the correct postSqrtPrice for various values
       })
 

--- a/test/__snapshots__/SwapToRatioTest.spec.ts.snap
+++ b/test/__snapshots__/SwapToRatioTest.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapToRatio #getPostSwapPrice  when initial deposit has excess of token1 and swap pushes the price beyond multiple initialized ticks gas 1`] = `50782`;
+exports[`SwapToRatio #getPostSwapPrice  when initial deposit has excess of token1 and swap does not push price beyond the next initialized tick gas 1`] = `18491`;
 
-exports[`SwapToRatio #getPostSwapPrice  when initial deposit has excess of token1 and swap pushes the price beyond the next initialized tick only gas 1`] = `33627`;
+exports[`SwapToRatio #getPostSwapPrice  when initial deposit has excess of token1 and swap pushes the price beyond multiple initialized ticks gas 1`] = `53029`;
 
-exports[`SwapToRatio #swapToNextInitializedTick when tested against actual swaps initial deposit has excess of token0 gas 1`] = `2738`;
+exports[`SwapToRatio #getPostSwapPrice  when initial deposit has excess of token1 and swap pushes the price beyond the next initialized tick only gas 1`] = `37176`;

--- a/test/__snapshots__/SwapToRatioTest.spec.ts.snap
+++ b/test/__snapshots__/SwapToRatioTest.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SwapToRatio #swapToNextInitializedTick when tested against actual swaps initial deposit has excess of token0 gas 1`] = `2738`;

--- a/test/__snapshots__/SwapToRatioTest.spec.ts.snap
+++ b/test/__snapshots__/SwapToRatioTest.spec.ts.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SwapToRatio #getPostSwapPrice  when initial deposit has excess of token1 and swap pushes the price beyond multiple initialized ticks gas 1`] = `50782`;
+
+exports[`SwapToRatio #getPostSwapPrice  when initial deposit has excess of token1 and swap pushes the price beyond the next initialized tick only gas 1`] = `33627`;
+
 exports[`SwapToRatio #swapToNextInitializedTick when tested against actual swaps initial deposit has excess of token0 gas 1`] = `2738`;


### PR DESCRIPTION
- [ ] improve `swapToNextInitializedTick` to more closely match real swaps ( will try SwapMath lib from core)
- [x] `nextInitializedTickWithinOneWord` to work going backwards
- [ ] "gas golfing"
- [ ] implement binary search